### PR TITLE
Fix status panel hang

### DIFF
--- a/frontend/src/app/api/status/summary/route.ts
+++ b/frontend/src/app/api/status/summary/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  const res = await fetch(`${process.env.API_URL}/status/summary`)
+  const data = await res.json()
+  return NextResponse.json(data)
+}

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -15,14 +15,25 @@ type StatusSummary = {
 
 export default function StatusPanel() {
   const [status, setStatus] = useState<StatusSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   // === Fetch backend /status/summary on load ===
   useEffect(() => {
-    fetch("https://relay.wildfireranch.us/status/summary")
-      .then(res => res.json())
-      .then(data => setStatus(data))
+    const loadStatus = async () => {
+      try {
+        const res = await fetch("/api/status/summary")
+        if (!res.ok) throw new Error(res.statusText)
+        const data = await res.json()
+        setStatus(data)
+      } catch (err) {
+        console.error("Failed to fetch status", err)
+        setError("Failed to load status")
+      }
+    }
+    loadStatus()
   }, [])
 
+  if (error) return <p>{error}</p>
   if (!status) return <p>Loading status...</p>
 
   return (


### PR DESCRIPTION
## Summary
- fetch status through Next.js API route
- handle fetch errors in the Status panel

## Testing
- `pytest -q`
- `ruff check .` *(fails: found 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843832431ac8327bd559ada2921389f