### PR TITLE
Fix index directory persistence

### DIFF
--- a/services/indexer.py
+++ b/services/indexer.py
@@ -7,17 +7,24 @@ import os
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.node_parser import CodeSplitter, SentenceSplitter
+from services.kb import INDEX_DIR
 
 # ---- Config ----
 ROOT_DIRS = ["./src", "./backend", "./frontend", "./docs"]  # Edit as needed
 
 # ---- Embedding Model ----
-embed_model = OpenAIEmbedding(model="text-embedding-3-large")
+model_name = (
+    os.getenv("KB_EMBED_MODEL")
+    or os.getenv("OPENAI_EMBED_MODEL")
+    or "text-embedding-3-large"
+)
+if model_name == "text-embedding-3-large":
+    embed_model = OpenAIEmbedding(model=model_name, dimensions=3072)
+else:
+    embed_model = OpenAIEmbedding(model=model_name)
 
 def index_directories():
-    """
-    Recursively scans ROOT_DIRS, splits files into semantic chunks, embeds, and stores index.
-    """
+    """Rebuild the semantic index from ROOT_DIRS and persist to ``INDEX_DIR``."""
     documents = []
     for dir_path in ROOT_DIRS:
         if os.path.exists(dir_path):
@@ -40,7 +47,7 @@ def index_directories():
     index = VectorStoreIndex.from_documents(
         documents, embed_model=embed_model, show_progress=True
     )
-    index.storage_context.persist(persist_dir="./data/index")
+    index.storage_context.persist(persist_dir=str(INDEX_DIR))
     print("Indexing complete!")
 
 if __name__ == "__main__":

--- a/services/kb.py
+++ b/services/kb.py
@@ -46,7 +46,10 @@ MODEL_NAME = (
     or os.getenv("OPENAI_EMBED_MODEL")
     or "text-embedding-3-large"
 )
-EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME, dimensions=3072)
+if MODEL_NAME == "text-embedding-3-large":
+    EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME, dimensions=3072)
+else:
+    EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME)
 
 # ─── Index paths (hard-wired) ──────────────────────────────────────────────
 PROJECT_ROOT = Path("/app")                                    # Railway image root


### PR DESCRIPTION
## Summary
- use the knowledge base index directory for indexing
- allow overriding the OpenAI embedding model
- persist vectors to the shared INDEX_DIR
- align embedding model selection between indexer and kb

## Testing
- `pytest -q`
- `ruff check .` *(fails: Found 28 errors)*


------
https://chatgpt.com/codex/tasks/task_e_6854c21751c083278b645f5e5cdbbaad