### PR TITLE
docs: correct OPENAI_API_KEY description and add RAILWAY_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For full details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `API_KEY`                | Backend  | Master API key for protected endpoints                     |
 | `ENABLE_ADMIN_TOOLS`     | Backend  | Enables `/admin/*` endpoints                               |
 | `FRONTEND_ORIGIN`        | Backend  | CORS allowlist override                                    |
-| `OPENAI_API_KEY`         | Backend  | LlamaIndex embedding model (e.g. `text-embedding-3-large`) |
+| `OPENAI_API_KEY`         | Backend  | OpenAI API key used for embeddings and chat |
 | `GOOGLE_CREDS_JSON`      | Backend  | Service account credentials (Base64-encoded)               |
 | `GOOGLE_TOKEN_JSON`      | Backend  | Optional OAuth token (Base64-encoded)                      |
 | `GOOGLE_CLIENT_ID`       | Both     | Google OAuth client ID                                     |
@@ -55,6 +55,7 @@ For full details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `INDEX_ROOT`             | Backend  | Filesystem path for semantic index                         |
 | `KB_EMBED_MODEL`         | Backend  | Embedding model for KB                                     |
 | `RELAY_PROJECT_ROOT`     | Backend  | Local path base                                            |
+| `RAILWAY_URL`           | Backend  | Default endpoint for queued actions |
 | `NEXT_PUBLIC_API_KEY`    | Frontend | API key exposed to the browser                             |
 | `NEXT_PUBLIC_API_URL`    | Frontend | Backend root for all API calls                             |
 | `NEXT_PUBLIC_RELAY_KEY`  | Frontend | Optional: UI config or dev-only usage                      |


### PR DESCRIPTION
## Summary
- fix the `OPENAI_API_KEY` description
- document new `RAILWAY_URL` variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cadc19f88327b706c5cd72f00591