### PR TITLE
Refactor index dir config

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -16,12 +16,13 @@ from fastapi.responses import FileResponse
 from pathlib import Path
 from datetime import datetime
 
+from services.config import INDEX_DIR
+
 # ------------------------------------------------------------------------
 # ENV/CONFIG SETUP
 # ------------------------------------------------------------------------
 router = APIRouter(prefix="/admin", tags=["admin-ops"])
 
-INDEX_DIR = Path(os.environ.get("INDEX_DIR", "/app/data/index"))  # Safe for Railway/Codespaces
 DATA_DIR = INDEX_DIR.parent
 ADMIN_LOG = DATA_DIR / "admin_events.log"
 

--- a/services/config.py
+++ b/services/config.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+
+PROJECT_ROOT = Path("/app")
+ENV_NAME = os.getenv("ENV", "dev")
+MODEL_NAME = (
+    os.getenv("KB_EMBED_MODEL")
+    or os.getenv("OPENAI_EMBED_MODEL")
+    or "text-embedding-3-large"
+)
+INDEX_ROOT = Path(
+    os.getenv("INDEX_ROOT", str(PROJECT_ROOT / "index" / ENV_NAME))
+)
+INDEX_DIR = Path(os.getenv("INDEX_DIR", str(INDEX_ROOT / MODEL_NAME)))
+INDEX_DIR.mkdir(parents=True, exist_ok=True)

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -9,7 +9,7 @@ import os
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.node_parser import CodeSplitter, SentenceSplitter
-from services.kb import INDEX_DIR
+from services.config import INDEX_DIR
 
 # ---- Config ----
 ROOT_DIRS = ["./src", "./backend", "./frontend", "./docs"]  # Edit as needed
@@ -59,63 +59,3 @@ def index_directories():
 
 if __name__ == "__main__":
     index_directories()
-services/kb.py
-+4
--1
-
-@@ -24,51 +24,54 @@ from llama_index.core import (
-    SimpleDirectoryReader,
-    StorageContext,
-    VectorStoreIndex,
-    load_index_from_storage,
-)
-from llama_index.core.extractors import TitleExtractor
-from llama_index.core.ingestion import IngestionPipeline
-from llama_index.core.node_parser import SentenceSplitter
-from llama_index.embeddings.openai import OpenAIEmbedding
-
-# ─── Logging ───────────────────────────────────────────────────────────────
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-7s %(name)s  %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-logger = logging.getLogger(__name__)
-logger.info("🔥 services.kb loaded")
-
-# ─── Model configuration ───────────────────────────────────────────────────
-MODEL_NAME = (
-    os.getenv("KB_EMBED_MODEL")
-    or os.getenv("OPENAI_EMBED_MODEL")
-    or "text-embedding-3-large"
-)
-EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME, dimensions=3072)
-if MODEL_NAME == "text-embedding-3-large":
-    EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME, dimensions=3072)
-else:
-    EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME)
-
-# ─── Index paths (hard-wired) ──────────────────────────────────────────────
-PROJECT_ROOT = Path("/app")                                    # Railway image root
-ENV_NAME     = os.getenv("ENV", "dev")                         # dev / prod / staging
-INDEX_ROOT   = PROJECT_ROOT / "index" / ENV_NAME               # /app/index/<env>
-INDEX_DIR    = INDEX_ROOT / MODEL_NAME                         # /app/index/<env>/<model>
-INDEX_DIR.mkdir(parents=True, exist_ok=True)
-
-# Scrub any stale model folders (e.g., old Ada or double-nested dirs)
-for path in INDEX_ROOT.iterdir():
-    if path.is_dir() and path.name != MODEL_NAME:
-        logger.warning("Removing stale index folder %s", path)
-        shutil.rmtree(path, ignore_errors=True)
-
-# ─── Ingestion pipeline ────────────────────────────────────────────────────
-ROOT       = Path(__file__).resolve().parent
-CODE_DIRS  = [ROOT.parent / p for p in ("src", "backend", "frontend")]
-DOCS_DIR   = ROOT.parent / "docs"
-CHUNK_SIZE, CHUNK_OVERLAP = 1024, 200
-
-INGEST_PIPELINE = IngestionPipeline(
-    transformations=[
-        TitleExtractor(llm=None),                           # no async LLM
-        SentenceSplitter(chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP),
-        EMBED_MODEL,

--- a/services/kb.py
+++ b/services/kb.py
@@ -20,6 +20,8 @@ import shutil
 from pathlib import Path
 from typing import List, Optional
 
+from services.config import INDEX_DIR, INDEX_ROOT
+
 from llama_index.core import (
     SimpleDirectoryReader,
     StorageContext,
@@ -51,12 +53,8 @@ if MODEL_NAME == "text-embedding-3-large":
 else:
     EMBED_MODEL = OpenAIEmbedding(model=MODEL_NAME)
 
-# ─── Index paths (hard-wired) ──────────────────────────────────────────────
-PROJECT_ROOT = Path("/app")                                    # Railway image root
-ENV_NAME     = os.getenv("ENV", "dev")                         # dev / prod / staging
-INDEX_ROOT   = PROJECT_ROOT / "index" / ENV_NAME               # /app/index/<env>
-INDEX_DIR    = INDEX_ROOT / MODEL_NAME                         # /app/index/<env>/<model>
-INDEX_DIR.mkdir(parents=True, exist_ok=True)
+# ─── Index paths (from config) ─────────────────────────────────────────────
+# INDEX_ROOT / INDEX_DIR provided by services.config
 
 # Scrub any stale model folders (e.g., old Ada or double-nested dirs)
 for path in INDEX_ROOT.iterdir():


### PR DESCRIPTION
## Summary
- centralize INDEX_DIR calculation in `services/config.py`
- use the shared constant in `kb`, `indexer`, and admin routes
- ensure directory can be overridden via environment variables

## Testing
- `python -m py_compile services/config.py services/indexer.py services/kb.py routes/admin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cc19c3d88327a8253fe0c145ef36