### PR TITLE
Use API_ROOT for logs fetch

### DIFF
--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { API_ROOT } from "@/lib/api";
 
 interface LogEntry {
   id: string;
@@ -24,7 +25,7 @@ export default function LogsPanel() {
   const [searchText, setSearchText] = useState<string>("");
 
   async function fetchLog() {
-    const res = await fetch("https://relay.wildfireranch.us/control/list_log", {
+    const res = await fetch(`${API_ROOT}/control/list_log`, {
       headers: {
         "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || ""
       }

--- a/frontend/src/components/MemoryPanel.tsx
+++ b/frontend/src/components/MemoryPanel.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { API_ROOT } from "@/lib/api";
 
 // Memory log entry interface
 interface MemoryEntry {
@@ -39,7 +40,7 @@ export default function MemoryPanel() {
     const start = Date.now();
     setFetchInfo({ status: "loading", time: 0 });
     try {
-      const res = await fetch("https://relay.wildfireranch.us/logs/sessions/all", {
+      const res = await fetch(`${API_ROOT}/logs/sessions/all`, {
         headers: {
           "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || ""
         }


### PR DESCRIPTION
## Summary
- use `API_ROOT` constant in `MemoryPanel` and `LogsPanel`
- keep API root defined via `NEXT_PUBLIC_API_URL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599f5b44048327971e44e170cc9b9e