### PR TITLE
Fix docs list limit enforcement

### DIFF
--- a/routes/docs.py
+++ b/routes/docs.py
@@ -57,9 +57,11 @@ async def list_docs(
     results: List[str] = []
     for sub in cats:
         for f in (BASE_DIR / sub).rglob("*.md"):
-            results.append(str(f.relative_to(BASE_DIR)))
             if len(results) >= limit:
                 break
+            results.append(str(f.relative_to(BASE_DIR)))
+        if len(results) >= limit:
+            break
     return {"files": results}
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -49,6 +49,12 @@ def test_docs_list():
     assert isinstance(data["files"], list)
 
 
+def test_docs_list_limit_enforced():
+    limit = 3
+    data = asyncio.run(list_docs(category="all", limit=limit))
+    assert len(data["files"]) <= limit
+
+
 def test_docs_sync(monkeypatch):
     monkeypatch.setattr(docs_routes, "sync_google_docs", lambda: ["foo.md"])
     data = asyncio.run(sync_docs())


### PR DESCRIPTION
## Summary
- stop appending docs after limit reached
- add regression test to ensure limit is respected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aa82586c8327bc7a6caccdfb0641