### PR TITLE
Implement caching for doc reads

### DIFF
--- a/tests/test_context_engine.py
+++ b/tests/test_context_engine.py
@@ -24,6 +24,7 @@ from services import context_engine as ce_module
 @pytest.fixture
 def ctx(tmp_path, monkeypatch):
     monkeypatch.setattr(ce_module, "kb", kb_stub)
+    ce_module.ContextEngine.clear_cache()
     # create global context file
     gen = tmp_path / "docs" / "generated"
     gen.mkdir(parents=True)
@@ -36,3 +37,28 @@ def ctx(tmp_path, monkeypatch):
 def test_context_build_includes_search_snippet(ctx):
     result = ctx.build_context("tell me something")
     assert "snippet" in result
+
+
+def test_env_root_change_clears_cache(tmp_path, monkeypatch):
+    ce_module.ContextEngine.clear_cache()
+    monkeypatch.setattr(ce_module, "kb", kb_stub)
+
+    base1 = tmp_path / "p1"
+    (base1 / "docs").mkdir(parents=True)
+    (base1 / "docs" / "a.md").write_text("A")
+
+    ctx1 = ce_module.ContextEngine(user_id="u", base=base1)
+    assert "A" in ctx1.read_docs()
+    # Modify file but cached result should remain the same
+    (base1 / "docs" / "a.md").write_text("A2")
+    assert "A" in ctx1.read_docs()
+
+    base2 = tmp_path / "p2"
+    (base2 / "docs").mkdir(parents=True)
+    (base2 / "docs" / "b.md").write_text("B")
+    monkeypatch.setenv("RELAY_PROJECT_ROOT", str(base2))
+
+    ctx2 = ce_module.ContextEngine(user_id="u")
+    content = ctx2.read_docs()
+    assert "B" in content
+    assert "A" not in content


### PR DESCRIPTION
## Summary
- add lru_cache-backed helpers for reading docs and source files
- invalidate cache when `RELAY_PROJECT_ROOT` changes or docs refresh
- clear caches in documentation routes after sync or reindex
- update tests to handle the new cache and verify invalidation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1eaa73388327a90af8b634b9b080