### PR TITLE
Make reflection step opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ For details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `ENV`                    | Backend  | `local`, `develop`, `main` for env-specific logic |
 | `API_KEY`                | Backend  | Master API key for protected endpoints            |
 | `ENABLE_ADMIN_TOOLS`     | Backend  | Enables `/admin/*` endpoints                      |
+| `ENABLE_REFLECT_AND_PLAN` | Backend  | Run reflection step before answering |
 | `FRONTEND_ORIGIN`        | Backend  | CORS allowlist override                           |
 | `OPENAI_API_KEY`         | Backend  | For embeddings and agent chat/completions         |
 | `GOOGLE_CREDS_JSON`      | Backend  | Service account credentials (Base64-encoded)      |
@@ -109,6 +110,9 @@ Echo will auto-inject:
 * Domain/project context (e.g. from `/context/context-solarshack.md`)
 * Function names from specified files
 * Global project context if present
+
+To run the optional reflection & planning step, set `ENABLE_REFLECT_AND_PLAN=1` or
+append `?reflect=1` to `/ask` requests.
 
 ---
 

--- a/routes/ask.py
+++ b/routes/ask.py
@@ -53,14 +53,15 @@ async def ask_get(
     request: Request,
     question: str = Query(...),
     x_user_id: Optional[str] = Header(None, alias="X-User-Id"),
-    debug: Optional[bool] = Query(False)
+    debug: Optional[bool] = Query(False),
+    reflect: Optional[bool] = Query(False)
 ):
     user_id = x_user_id or "anonymous"
     try:
         ce = ContextEngine(user_id=user_id)
         context = ce.build_context(question)
         context_files, used_global_context = extract_context_meta(context)
-        result = await answer(user_id, question, context=context)
+        result = await answer(user_id, question, context=context, reflect=reflect)
         if isinstance(result, str):
             response = result
             action = None
@@ -99,7 +100,8 @@ async def ask_post(
     request: Request,
     payload: dict,
     x_user_id: Optional[str] = Header(None, alias="X-User-Id"),
-    debug: Optional[bool] = Query(False)
+    debug: Optional[bool] = Query(False),
+    reflect: Optional[bool] = Query(False)
 ):
     user_id = x_user_id or "anonymous"
     question = payload.get("question", "")
@@ -109,7 +111,7 @@ async def ask_post(
         ce = ContextEngine(user_id=user_id)
         context = ce.build_context(question)
         context_files, used_global_context = extract_context_meta(context)
-        result = await answer(user_id, question, context=context)
+        result = await answer(user_id, question, context=context, reflect=reflect)
         if isinstance(result, str):
             response = result
             action = None
@@ -149,7 +151,8 @@ async def ask_post(
 async def ask_stream(
     request: Request,
     payload: dict,
-    x_user_id: Optional[str] = Header(None, alias="X-User-Id")
+    x_user_id: Optional[str] = Header(None, alias="X-User-Id"),
+    reflect: Optional[bool] = Query(False)
 ):
     user_id = x_user_id or "anonymous"
     question = payload.get("question", "")
@@ -164,7 +167,7 @@ async def ask_stream(
 
         async def streamer() -> AsyncGenerator[str, None]:
             nonlocal captured_action
-            async for chunk in answer(user_id, question, context=context, stream=True):
+            async for chunk in answer(user_id, question, context=context, stream=True, reflect=reflect):
                 full_response.append(chunk)
                 yield chunk
 


### PR DESCRIPTION
## Summary
- add `ENABLE_REFLECT_AND_PLAN` environment flag
- make agent reflection optional and expose via `/ask` query param
- document the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a203cd7248327bc943b3778c7fea2