### PR TITLE
Fix indexer compatibility

### DIFF
--- a/services/indexer.py
+++ b/services/indexer.py
@@ -122,8 +122,10 @@ def index_directories():
 
     # --- 6. Index & Persist ---
     print(f"Total nodes to index: {len(all_chunked_nodes)}")
-    index = VectorStoreIndex.from_nodes(
-        all_chunked_nodes, embed_model=embed_model, show_progress=True
+    index = VectorStoreIndex(
+        nodes=all_chunked_nodes,
+        embed_model=embed_model,
+        show_progress=True
     )
     index.storage_context.persist(persist_dir="./data/index")
     index.storage_context.persist(persist_dir=str(INDEX_DIR))


### PR DESCRIPTION
## Summary
- update indexer to create `VectorStoreIndex` directly rather than using `.from_nodes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4eef59608327b6ed561a76435992