### PR TITLE
Implement missing context helpers

### DIFF
--- a/services/context_injector.py
+++ b/services/context_injector.py
@@ -3,8 +3,9 @@
 
 import os
 from pathlib import Path
-from services.indexer import collect_code_context  # existing
-from services.kb import query_index                # existing
+# Lightweight helpers for reading code files and KB search
+from services.indexer import collect_code_context
+from services.kb import query_index
 
 # -- Extract function/class names from files --
 def extract_functions(files, base_dir="./"):

--- a/services/indexer.py
+++ b/services/indexer.py
@@ -5,6 +5,7 @@
 
 import os
 import glob
+from pathlib import Path
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex, Document
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.core.node_parser import CodeSplitter, SentenceSplitter
@@ -78,6 +79,18 @@ def get_language_from_path(file_path: str) -> str:
     elif file_path.endswith(".cpp"):
         return "cpp"
     return "python"  # fallback
+
+def collect_code_context(files: list[str], base_dir: str = "./") -> str:
+    """Read and join contents of files for prompt context."""
+    contents: list[str] = []
+    for f in files:
+        path = Path(base_dir) / f
+        if path.exists() and path.is_file():
+            try:
+                contents.append(f"### {f}\n" + path.read_text())
+            except Exception:
+                continue
+    return "\n\n".join(contents)
 
 def index_directories():
     """Scans all PRIORITY_INDEX_PATHS, splits, tags with tier, and embeds for semantic search."""

--- a/services/kb.py
+++ b/services/kb.py
@@ -281,6 +281,11 @@ def search(
 def api_search(query: str, k: int = 4, search_type: str = "all") -> List[dict]:
     return search(query=query, k=k, search_type=search_type)
 
+def query_index(query: str, k: int = 4) -> str:
+    """Return formatted search snippets for a query."""
+    results = search(query, k=k)
+    return "\n\n".join(f"{r['title']}:\n{r['snippet']}" for r in results)
+
 def api_reindex(verbose: bool = False) -> dict:
     global _INDEX_CACHE
     embed_all(verbose=verbose)


### PR DESCRIPTION
## Summary
- implement `collect_code_context` in `services.indexer`
- implement `query_index` in `services.kb`
- update `context_injector` imports
- maintain passing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5fdb644483278358a26cea43b211