### PR TITLE
Update auto context path

### DIFF
--- a/cron/cron_generate_auto_context.py
+++ b/cron/cron_generate_auto_context.py
@@ -9,8 +9,8 @@ INTERVAL_SECONDS = 86400  # 12 hours
 
 def run():
     while True:
-        print(f"[CRON] Running generate_global_context_auto.py at {datetime.utcnow().isoformat()}Z")
-        subprocess.run(["python", "scripts/generate_global_context_auto.py"])
+        print(f"[CRON] Running generate_global_context.auto.py at {datetime.utcnow().isoformat()}Z")
+        subprocess.run(["python", "scripts/generate_global_context.auto.py"])
         time.sleep(INTERVAL_SECONDS)
 
 if __name__ == "__main__":

--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 def generate_auto_context():
     try:
         result = subprocess.run(
-            ["python", "scripts/generate_global_context_auto.py"],
+            ["python", "scripts/generate_global_context.auto.py"],
             capture_output=True, text=True, check=True
         )
         return JSONResponse({"status": "success", "output": result.stdout})

--- a/routes/status_code.py
+++ b/routes/status_code.py
@@ -15,7 +15,7 @@ CODE_PATHS = [
     ("routes/admin_routes.py", "core"),
     ("routes/status.py", "support"),
     ("scripts/sync_context_docs.py", "support"),
-    ("scripts/generate_global_context_auto.py", "support"),
+    ("scripts/generate_global_context.auto.py", "support"),
     ("main.py", "entrypoint")
 ]
 

--- a/scripts/generate_code_map.py
+++ b/scripts/generate_code_map.py
@@ -12,7 +12,7 @@ FILES = [
     ("routes/admin_routes.py", "core"),
     ("routes/status.py", "support"),
     ("scripts/sync_context_docs.py", "support"),
-    ("scripts/generate_global_context_auto.py", "support"),
+    ("scripts/generate_global_context.auto.py", "support"),
     ("main.py", "entrypoint")
 ]
 

--- a/scripts/generate_global_context.auto.py
+++ b/scripts/generate_global_context.auto.py
@@ -1,4 +1,4 @@
-# File: scripts/generate_global_context_auto.py
+# File: scripts/generate_global_context.auto.py
 # Purpose: Auto-generate /docs/generated/global_context.auto.md from all /context/*.md
 
 from pathlib import Path

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,0 +1,20 @@
+import json
+import subprocess
+from routes import admin_routes
+
+
+def test_generate_auto_context_runs_correct_script(monkeypatch):
+    called = {}
+
+    class Dummy:
+        stdout = "ok"
+
+    def fake_run(cmd, capture_output=True, text=True, check=True):
+        called["cmd"] = cmd
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    response = admin_routes.generate_auto_context()
+    assert called["cmd"] == ["python", "scripts/generate_global_context.auto.py"]
+    assert json.loads(response.body) == {"status": "success", "output": "ok"}


### PR DESCRIPTION
## Summary
- call `scripts/generate_global_context.auto.py` in admin route
- update cron, code map, and status docs to reference new path
- fix script header comment
- test admin route uses the correct script path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b618e77608327a36b845d262d0392