### PR TITLE
Add score threshold option for KB search

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `POST_AUTH_REDIRECT_URI` | Backend  | Redirect URI post-auth                            |
 | `INDEX_ROOT`             | Backend  | Filesystem path for semantic index                |
 | `KB_EMBED_MODEL`         | Backend  | Embedding model for KB                            |
+| `KB_SCORE_THRESHOLD`     | Backend  | Minimum similarity score for KB search |
 | `RELAY_PROJECT_ROOT`     | Backend  | Root path for doc/code/context scans              |
 | `NEXT_PUBLIC_API_KEY`    | Frontend | API key exposed to browser                        |
 | `NEXT_PUBLIC_API_URL`    | Frontend | Backend root for all API calls                    |
@@ -113,6 +114,7 @@ Echo will auto-inject:
 
 To run the optional reflection & planning step, set `ENABLE_REFLECT_AND_PLAN=1` or
 append `?reflect=1` to `/ask` requests.
+Set `KB_SCORE_THRESHOLD` or pass `?score_threshold=0.15` to filter low-scoring KB results.
 
 ---
 

--- a/services/context_engine.py
+++ b/services/context_engine.py
@@ -29,9 +29,16 @@ class ContextEngine:
             globals()["_CACHED_ENV_ROOT"] = env_root
         self.base = Path(env_root).resolve() if env_root else Path(base or Path.cwd())
 
-    def build_context(self, query: str, k: int = 8) -> str:
+    def build_context(
+        self,
+        query: str,
+        k: int = 8,
+        score_threshold: Optional[float] = None,
+    ) -> str:
         """
         Build a tiered, labeled agent context window using prioritized semantic search.
+        Optionally filter out low-scoring KB hits.
+
         Returns a prompt like:
             # [Global Context]
             ...
@@ -43,7 +50,12 @@ class ContextEngine:
             ...
         """
         # 1. Priority-aware semantic search (returns ordered, tier-labeled blocks)
-        results = kb.search(query, k=k, user_id=self.user_id)
+        results = kb.search(
+            query,
+            k=k,
+            user_id=self.user_id,
+            score_threshold=score_threshold,
+        )
         blocks = []
         for r in results:
             # Compose a readable label based on tier


### PR DESCRIPTION
## Summary
- let `ContextEngine.build_context` accept an optional `score_threshold`
- pass the threshold to `kb.search`
- expose `score_threshold` on `/ask` routes via query param or `KB_SCORE_THRESHOLD` env
- document new option in README
- test that the threshold is forwarded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b658684bc8327a6b430335d42ed25