### PR TITLE
fix(frontend): resolve no-unused-expressions in toggleTag

### DIFF
--- a/frontend/src/components/MemoryPanel.tsx
+++ b/frontend/src/components/MemoryPanel.tsx
@@ -102,7 +102,11 @@ export default function MemoryPanel() {
     setMemory(prev => {
       const clone = [...prev]
       const tags = new Set(clone[index].tags || [])
-      tags.has(tag) ? tags.delete(tag) : tags.add(tag)
+      if (tags.has(tag)) {
+        tags.delete(tag)
+      } else {
+        tags.add(tag)
+      }
       clone[index].tags = Array.from(tags)
       return clone
     })


### PR DESCRIPTION
## Summary
- remove ternary expression from `toggleTag` to avoid no-unused-expressions lint issue

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c704cc730832780d10a42b0bd4bed