### PR TITLE
Add metrics chart page with sidebar link

### DIFF
--- a/frontend/src/app/metricschart/page.tsx
+++ b/frontend/src/app/metricschart/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import MetricsChart from '@/components/MetricsCharts/MetricsCharts'
+
+export default function MetricsChartPage() {
+  return (
+    <main className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Metrics</h1>
+      <MetricsChart />
+    </main>
+  )
+}

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ const sections = [
       { href: "/ask", label: "Ask Echo", icon: "💬" },
       { href: "/docs", label: "Docs", icon: "📚" },
       { href: "/status", label: "Status", icon: "📊" },
+      { href: "/metricschart", label: "Metrics", icon: "📈" },
       { href: "/editor", label: "Sandbox", icon: "🧩" }, // ← Added here
     ],
   },


### PR DESCRIPTION
## Summary
- add MetricsChart page for easier navigation
- link to metrics in the sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ca74292488327ad2c44c7b3955181