### PR TITLE
Add critic agent package entrypoint

### DIFF
--- a/agents/codex_agent.py
+++ b/agents/codex_agent.py
@@ -10,7 +10,7 @@ from openai import AsyncOpenAI, OpenAIError
 from utils.patch_utils import validate_patch_format
 from core.logging import log_event
 from dotenv import load_dotenv
-from agents.critic_agent import run_all as run_critics
+from agents.critic_agent import run_critics
 
 load_dotenv()
 

--- a/agents/critic_agent/__init__.py
+++ b/agents/critic_agent/__init__.py
@@ -1,0 +1,6 @@
+from .run import run_critics
+
+# Expose run_critics under two names for backward compatibility
+run_all = run_critics
+
+__all__ = ["run_critics", "run_all"]

--- a/agents/docs_agent.py
+++ b/agents/docs_agent.py
@@ -5,7 +5,7 @@
 import os
 import traceback
 from openai import AsyncOpenAI, OpenAIError
-from agents.critic_agent import run_all as run_critics
+from agents.critic_agent import run_critics
 from core.logging import log_event
 
 client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -7,7 +7,7 @@ import os
 import traceback
 from openai import AsyncOpenAI, OpenAIError
 from core.logging import log_event
-from agents.critic_agent import run_all as run_critics
+from agents.critic_agent import run_critics
 
 # === Model Configuration ===
 MODEL = os.getenv("PLANNER_MODEL", "gpt-4o")


### PR DESCRIPTION
## Summary
- expose critic runner via `agents.critic_agent` package
- update Codex, Docs, and Planner agents to import `run_critics` directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6861ae71664c83278da47f98aa311bb9