### PR TITLE
Move codex stream to codex_agent

### DIFF
--- a/agents/codex_agent.py
+++ b/agents/codex_agent.py
@@ -5,7 +5,7 @@
 # Dependencies: OpenAI (GPT-4), Relay config, project file context
 
 import os
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, AsyncGenerator
 from openai import AsyncOpenAI, OpenAIError
 from utils.patch_utils import validate_patch_format
 from core.logging import log_event
@@ -85,6 +85,33 @@ async def handle(message: str, context: str, user_id: Optional[str] = None) -> D
         "response": response,
         "action": action
     }
+
+
+# === Streaming Variant ===
+async def stream(message: str, context: str, user_id: Optional[str] = None) -> AsyncGenerator[str, None]:
+    """Stream CodexAgent patch response line by line."""
+    if not message or not context:
+        yield "[Error] Missing message or context."
+        return
+
+    prompt = build_prompt(message, context)
+
+    try:
+        openai_stream = await client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": "You are a senior software engineer generating code patches from user requests."},
+                {"role": "user", "content": prompt}
+            ],
+            temperature=0.3,
+            stream=True
+        )
+        async for chunk in openai_stream:
+            delta = chunk.choices[0].delta.content
+            if delta:
+                yield delta
+    except Exception as e:
+        yield f"[Error] Codex stream failed: {str(e)}"
 
 
 # === Prompt Builder ===

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -23,3 +23,21 @@ async def test_ask_stream_rejects_bad_input():
     async with AsyncClient(app=app, base_url="http://test") as client:
         response = await client.post("/ask/stream", json={})
         assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_codex_stream_endpoint(monkeypatch):
+    async def dummy_stream(message: str, context: str, user_id=None):
+        yield "patch1"
+        yield "patch2"
+
+    from agents import codex_agent
+    monkeypatch.setattr(codex_agent, "stream", dummy_stream)
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            "/ask/codex_stream",
+            json={"question": "fix", "context": "ctx"}
+        )
+        assert resp.status_code == 200
+        assert resp.text == "patch1patch2"

--- a/utils/patch_utils.py
+++ b/utils/patch_utils.py
@@ -1,6 +1,6 @@
 """Utilities for working with code patches."""
 
-from typing import Mapping
+from typing import Mapping, AsyncGenerator, Optional
 
 REQUIRED_KEYS = {"type", "target_file", "patch", "reason"}
 
@@ -10,3 +10,11 @@ def validate_patch_format(patch: Mapping[str, object]) -> bool:
     if not isinstance(patch, Mapping):
         return False
     return REQUIRED_KEYS.issubset(patch.keys())
+
+
+async def stream(message: str, context: str, user_id: Optional[str] = None) -> AsyncGenerator[str, None]:
+    """Re-export codex_agent.stream for backward compatibility."""
+    from agents.codex_agent import stream as codex_stream
+
+    async for chunk in codex_stream(message, context, user_id):
+        yield chunk


### PR DESCRIPTION
## Summary
- expose Codex streaming helper in `codex_agent`
- re-export the coroutine from `patch_utils`
- add regression test for `/ask/codex_stream`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861b41bebe0832793e4ac25744159ce