### PR TITLE
Unify agent logging

### DIFF
--- a/agents/mcp_agent.py
+++ b/agents/mcp_agent.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from agents import planner_agent, codex_agent
 from services.context_injector import build_context
-from utils.logger import log_event
+from core.logging import log_event
 from services.queue import queue_action
 
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,6 +1,6 @@
 # File: utils/logger.py
-from datetime import datetime
+"""Compatibility wrapper forwarding to :mod:`core.logging`."""
 
-def log_event(event_type: str, payload: dict):
-    timestamp = datetime.utcnow().isoformat()
-    print(f"[{timestamp}] {event_type.upper()} → {payload}")
+from core.logging import log_event
+
+__all__ = ["log_event"]


### PR DESCRIPTION
## Summary
- use `core.logging.log_event` for MCP agent
- make `utils.logger` forward to the central logger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861b9e276c483278d00c9126b24ac31