### PR TITLE
Add MCP run endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ To run the optional reflection & planning step, set `ENABLE_REFLECT_AND_PLAN=1` 
 append `?reflect=1` to `/ask` requests.
 Set `KB_SCORE_THRESHOLD` or pass `?score_threshold=0.15` to filter low-scoring KB results.
 
+### MCP Run Example:
+
+```bash
+POST /mcp/run
+{
+  "query": "Add error handling",
+  "files": ["app/main.py"],
+  "role": "codex"
+}
+```
+
+The MCP orchestrates planner or codex roles with full context injection.
+
 ---
 
 ## 🔎 Key Endpoints
@@ -133,6 +146,8 @@ Set `KB_SCORE_THRESHOLD` or pass `?score_threshold=0.15` to filter low-scoring K
 | ------------------------------ | ---------------------------------------------- | ------------- |
 | `/ask`                         | GPT Q\&A with code+context                     | ✅             |
 | `/kb/search`                   | Semantic search over code/docs/context         | ✅             |
+| `/mcp/run`                     | Master Control Program orchestrator
+  | ✅             |
 | `/docs/sync`                   | Google Docs → Markdown/context sync            | ✅             |
 | `/admin/reindex`               | Manual rebuild of semantic index               | ✅             |
 | `/admin/generate_auto_context` | Regenerate auto global context from `/context` | ✅             |

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ from routes.kb import router as kb_router
 from routes.search import router as search_router
 from routes.admin import router as admin_router
 from routes.codex import router as codex_router
+from routes.mcp import router as mcp_router
 
 app.include_router(ask_router)
 app.include_router(status_router)
@@ -83,6 +84,7 @@ app.include_router(debug_router)
 app.include_router(kb_router)
 app.include_router(search_router)
 app.include_router(codex_router)
+app.include_router(mcp_router)
 
 # Admin tools
 if os.getenv("ENABLE_ADMIN_TOOLS", "").strip().lower() in ("1", "true", "yes"):

--- a/routes/mcp.py
+++ b/routes/mcp.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException, Request, Header
+from typing import Optional
+from agents.mcp_agent import run_mcp
+
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+@router.post("/run")
+async def mcp_run(
+    request: Request,
+    x_user_id: Optional[str] = Header(None, alias="X-User-Id")
+):
+    data = await request.json()
+    query = data.get("query") or data.get("question") or data.get("prompt")
+    if not query:
+        raise HTTPException(status_code=422, detail="Missing 'query' in payload")
+    files = data.get("files")
+    topics = data.get("topics")
+    role = data.get("role", "planner")
+    debug = data.get("debug", False)
+    user_id = x_user_id or "anonymous"
+    return await run_mcp(
+        query=query,
+        files=files,
+        topics=topics,
+        role=role,
+        user_id=user_id,
+        debug=debug,
+    )
+

--- a/tests/test_mcp_route.py
+++ b/tests/test_mcp_route.py
@@ -1,0 +1,27 @@
+import pytest
+from httpx import AsyncClient
+from main import app
+
+@pytest.mark.asyncio
+async def test_mcp_run_invokes_agent(monkeypatch):
+    called = {}
+
+    async def fake_run_mcp(query, files=None, topics=None, role="planner", user_id="anonymous", debug=False):
+        called['args'] = {
+            'query': query,
+            'files': files,
+            'topics': topics,
+            'role': role,
+            'user_id': user_id,
+            'debug': debug,
+        }
+        return {"ok": True}
+
+    monkeypatch.setattr("routes.mcp.run_mcp", fake_run_mcp)
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post("/mcp/run", json={"query": "hi"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert called['args']['query'] == "hi"
+


### PR DESCRIPTION
## Summary
- add `/mcp/run` route invoking `run_mcp`
- register the new router in `main.py`
- document MCP usage and endpoint in README
- test new endpoint with `AsyncClient`

## Testing
- `pip install httpx openai pytest-asyncio` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861d2cb476c8327a6ab57c4c863f97a