### PR TITLE
Update API route env var

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,6 +16,16 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Environment Variables
+
+Create a `.env.local` file and provide the base URL of the backend API:
+
+```dotenv
+NEXT_PUBLIC_API_URL=http://localhost:8000
+```
+
+This variable is required by the API route handlers in `src/app/api`.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/frontend/src/app/api/docs/list/route.ts
+++ b/frontend/src/app/api/docs/list/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 
 export async function GET() {
-  const res = await fetch(`${process.env.API_URL}/docs/list`)
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/docs/list`)
   const data = await res.json()
   return NextResponse.json(data)
 }

--- a/frontend/src/app/api/docs/view/route.ts
+++ b/frontend/src/app/api/docs/view/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server"
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
   const path = url.searchParams.get("path")
-  const res = await fetch(`${process.env.API_URL}/docs/view?path=${encodeURIComponent(path || "")}`)
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/docs/view?path=${encodeURIComponent(path || "")}`)
   const data = await res.json()
   return NextResponse.json(data)
 }

--- a/frontend/src/app/api/kb/search/route.ts
+++ b/frontend/src/app/api/kb/search/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 
 export async function POST(req: NextRequest) {
   const body = await req.json()
-  const res = await fetch(`${process.env.API_URL}/kb/search`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/kb/search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/frontend/src/app/api/status/summary/route.ts
+++ b/frontend/src/app/api/status/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 
 export async function GET() {
-  const res = await fetch(`${process.env.API_URL}/status/summary`)
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/status/summary`)
   const data = await res.json()
   return NextResponse.json(data)
 }


### PR DESCRIPTION
## Summary
- use `process.env.NEXT_PUBLIC_API_URL` in all API routes
- document the new environment variable in the frontend README

## Testing
- `pytest -q`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861d7bd72088327bb35d1a95e856007