### PR TITLE
Add regex-based CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `ENABLE_ADMIN_TOOLS`     | Backend  | Enables `/admin/*` endpoints                      |
 | `ENABLE_REFLECT_AND_PLAN` | Backend  | Run reflection step before answering |
 | `FRONTEND_ORIGIN`        | Backend  | CORS allowlist override                           |
+| `FRONTEND_ORIGIN_REGEX`  | Backend  | Regex pattern for allowed CORS origins |
 | `OPENAI_API_KEY`         | Backend  | For embeddings and agent chat/completions         |
 | `GOOGLE_CREDS_JSON`      | Backend  | Service account credentials (Base64-encoded)      |
 | `GOOGLE_TOKEN_JSON`      | Backend  | Optional OAuth token (Base64-encoded)             |

--- a/main.py
+++ b/main.py
@@ -46,16 +46,21 @@ cors_origins = ["*"]
 allow_creds = False  # '*' requires credentials = False
 
 override_origin = os.getenv("FRONTEND_ORIGIN")
+origin_regex = os.getenv("FRONTEND_ORIGIN_REGEX")
 if override_origin:
     cors_origins = [o.strip() for o in override_origin.split(",") if o.strip()]
     allow_creds = True
     logging.info(f"🔒 CORS restricted to: {cors_origins}")
+elif origin_regex:
+    allow_creds = True
+    logging.info(f"🔒 CORS regex restriction: {origin_regex}")
 else:
     logging.warning("🔓 CORS DEBUG MODE ENABLED: allow_origins='*', allow_credentials=False")
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,
+    allow_origin_regex=origin_regex,
     allow_credentials=allow_creds,
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["*"],

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+from httpx import AsyncClient
+import os
+
+@pytest.mark.asyncio
+async def test_cors_regex(monkeypatch):
+    monkeypatch.setenv("FRONTEND_ORIGIN_REGEX", r"http://localhost:\d+")
+    import main
+    importlib.reload(main)
+    async with AsyncClient(app=main.app, base_url="http://test") as client:
+        resp = await client.options(
+            "/test-cors",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    monkeypatch.delenv("FRONTEND_ORIGIN_REGEX", raising=False)
+    importlib.reload(main)


### PR DESCRIPTION
## Summary
- support optional `FRONTEND_ORIGIN_REGEX` env var
- pass the regex to FastAPI CORS middleware
- document the new variable in README
- test that regex based origins are allowed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861db151df483279898d8fe8d141120