### PR TITLE
Add frontend origin vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ NEXT_PUBLIC_RELAY_KEY=
 NEXT_PUBLIC_API_URL=http://localhost:8000
 #NEXT_PUBLIC_API_URL=https://relay.staging.wildfireranch.us
 #NEXT_PUBLIC_API_URL=https://relay.wildfireranch.us
+
+# === \ud83c\udf0e Allowed Frontend Origin(s) ===
+FRONTEND_ORIGIN=http://localhost:3000
+#FRONTEND_ORIGIN=https://status.wildfireranch.us
+#FRONTEND_ORIGIN_REGEX=
+#FRONTEND_ORIGIN_REGEX=https://status\.wildfireranch\.us

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ For details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `API_KEY`                | Backend  | Master API key for protected endpoints            |
 | `ENABLE_ADMIN_TOOLS`     | Backend  | Enables `/admin/*` endpoints                      |
 | `ENABLE_REFLECT_AND_PLAN` | Backend  | Run reflection step before answering |
-| `FRONTEND_ORIGIN`        | Backend  | CORS allowlist override                           |
-| `FRONTEND_ORIGIN_REGEX`  | Backend  | Regex pattern for allowed CORS origins |
+| `FRONTEND_ORIGIN`        | Backend  | Comma-separated CORS origins. Must include your frontend domain (e.g. https://status.wildfireranch.us) |
+| `FRONTEND_ORIGIN_REGEX`  | Backend  | Regex pattern for allowed CORS origins if using wildcards |
 | `OPENAI_API_KEY`         | Backend  | For embeddings and agent chat/completions         |
 | `GOOGLE_CREDS_JSON`      | Backend  | Service account credentials (Base64-encoded)      |
 | `GOOGLE_TOKEN_JSON`      | Backend  | Optional OAuth token (Base64-encoded)             |

--- a/railway.json
+++ b/railway.json
@@ -1,10 +1,13 @@
 {
   "services": [
     {
-      "name": "relay-agent",           
+      "name": "relay-agent",
       "startCommand": "python main.py",
-      "healthcheckPath": "/status",    
-      "port": 8000                     
+      "healthcheckPath": "/status",
+      "port": 8000,
+      "env": {
+        "FRONTEND_ORIGIN": "https://status.wildfireranch.us"
+      }
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "FRONTEND_ORIGIN": "https://status.wildfireranch.us"
+  }
+}


### PR DESCRIPTION
## Summary
- expose FRONTEND_ORIGIN and FRONTEND_ORIGIN_REGEX in `.env.example`
- document them in README with an explanation
- set `FRONTEND_ORIGIN` in `railway.json` and `vercel.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861df011eec8327864cd5fb99604812