### PR TITLE
fix frontend API URLs

### DIFF
--- a/frontend/src/app/codex/page.tsx
+++ b/frontend/src/app/codex/page.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { useState } from "react";
 import { CodexEditor, CodexPromptBar, CodexPatchView } from "@/components/Codex";
 import { Button } from "@/components/ui/button";
+import { API_ROOT } from "@/lib/api";
 
 const CodexPage: React.FC = () => {
   const [code, setCode] = useState<string>("");
@@ -23,7 +24,7 @@ const CodexPage: React.FC = () => {
     setParsedPatch(null);
 
     try {
-      const res = await fetch("/ask/codex_stream", {
+      const res = await fetch(`${API_ROOT}/ask/codex_stream`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ question: prompt, context: code }),
@@ -62,7 +63,7 @@ const CodexPage: React.FC = () => {
     setStatus("⏳ Applying patch...");
 
     try {
-      const res = await fetch("/codex/apply_patch", {
+      const res = await fetch(`${API_ROOT}/codex/apply_patch`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
+++ b/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
+import { API_ROOT } from "@/lib/api";
 
 type ActionStatus = "pending" | "approved" | "denied";
 
@@ -52,7 +53,7 @@ export default function ActionQueuePanel() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/control/list_queue", {
+      const res = await fetch(`${API_ROOT}/control/list_queue`, {
         headers: {
           "X-API-Key": API_KEY,
           "X-User-Id": USER_ID
@@ -71,7 +72,7 @@ export default function ActionQueuePanel() {
   const updateStatus = async (id: string, action: "approve" | "deny") => {
     setProcessing(id + action);
     try {
-      const res = await fetch(`/control/${action}_action`, {
+      const res = await fetch(`${API_ROOT}/control/${action}_action`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/AuditPanel/AuditPanel.tsx
+++ b/frontend/src/components/AuditPanel/AuditPanel.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { API_ROOT } from "@/lib/api";
 
 // === Types ===
 type LogEntry = {
@@ -45,7 +46,7 @@ export default function AuditPanel() {
   // === Fetch audit logs from backend ===
   async function fetchLog() {
     try {
-      const res = await fetch("/control/list_log", {
+      const res = await fetch(`${API_ROOT}/control/list_log`, {
         headers: { "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || "" }
       });
       if (!res.ok) throw new Error("Bad response");
@@ -60,7 +61,7 @@ export default function AuditPanel() {
   // === Fetch related queue action by id ===
   async function fetchRelated(id: string) {
     try {
-      const res = await fetch("/control/list_queue", {
+      const res = await fetch(`${API_ROOT}/control/list_queue`, {
         headers: { "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || "" }
       });
       if (!res.ok) throw new Error("Bad response");

--- a/frontend/src/components/Codex/page.tsx
+++ b/frontend/src/components/Codex/page.tsx
@@ -2,6 +2,7 @@
 
 import { CodexEditor, CodexPromptBar, CodexPatchView } from "@/components/Codex";
 import { useState } from "react";
+import { API_ROOT } from "@/lib/api";
 
 export default function CodexPage() {
   const [code, setCode] = useState("");
@@ -14,7 +15,7 @@ export default function CodexPage() {
       <CodexEditor code={code} setCode={setCode} />
       <CodexPromptBar prompt={prompt} setPrompt={setPrompt} onSubmit={async () => {
         setStreamingPatch("⏳ Working...");
-        const res = await fetch("/ask/codex_stream", {
+        const res = await fetch(`${API_ROOT}/ask/codex_stream`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ question: prompt, context: code }),

--- a/frontend/src/components/GmailOps/GmailOpsPanel.tsx
+++ b/frontend/src/components/GmailOps/GmailOpsPanel.tsx
@@ -3,6 +3,7 @@
 "use client";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { API_ROOT } from "@/lib/api";
 
 // Explicitly type the Email shape
 type Email = {
@@ -20,7 +21,7 @@ export default function GmailOpsPanel() {
   const [emails, setEmails] = useState<Email[]>([]);
 
   async function send() {
-    const res = await fetch("/control/send_email", {
+    const res = await fetch(`${API_ROOT}/control/send_email`, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || "" },
       body: JSON.stringify({ to_email: to, subject, body })
@@ -30,7 +31,7 @@ export default function GmailOpsPanel() {
   }
 
   async function list() {
-    const res = await fetch("/control/list_email", {
+    const res = await fetch(`${API_ROOT}/control/list_email`, {
       headers: { "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || "" }
     });
     const data = await res.json();


### PR DESCRIPTION
## Summary
- route FastAPI calls through API_ROOT to avoid 405 errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6861e06b93bc8327b0378ef6528ddadd