### PR TITLE
Update README for Vercel API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ For details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `NEXT_PUBLIC_API_KEY`    | Frontend | API key exposed to browser                        |
 | `NEXT_PUBLIC_API_URL`    | Frontend | Backend root for all API calls                    |
 
+### Vercel Deployment
+
+Set `NEXT_PUBLIC_API_URL` to your public backend URL when deploying the frontend to Vercel (e.g. `https://relay.wildfireranch.us`). Ensure the backend allows this origin by adding it to `FRONTEND_ORIGIN`.
+
+
 ---
 
 ## 🧠 Context & Memory Intelligence


### PR DESCRIPTION
## Summary
- clarify how `NEXT_PUBLIC_API_URL` should be set when deploying to Vercel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6861e1fbe3448327a2e8b4567ba2b9ce