### PR TITLE
Add OpenAI timeout & retry config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ API_KEY=relay-dev
 
 # === 🤖 OpenAI Configuration ===
 OPENAI_API_KEY=s
+OPENAI_TIMEOUT=30
+OPENAI_MAX_RETRIES=2
 # === 📄 Google OAuth 2.0 Credentials ===
 GOOGLE_CREDS_JSON=
 GOOGLE_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ For details, see [`/docs/PROJECT_SUMMARY.md`](./docs/PROJECT_SUMMARY.md)
 | `FRONTEND_ORIGIN`        | Backend  | Comma-separated CORS origins. Must include your frontend domain (e.g. https://status.wildfireranch.us) |
 | `FRONTEND_ORIGIN_REGEX`  | Backend  | Regex pattern for allowed CORS origins if using wildcards |
 | `OPENAI_API_KEY`         | Backend  | For embeddings and agent chat/completions         |
+| `OPENAI_TIMEOUT`         | Backend  | Timeout (seconds) for OpenAI requests               |
+| `OPENAI_MAX_RETRIES`     | Backend  | Retry attempts for OpenAI calls                     |
 | `GOOGLE_CREDS_JSON`      | Backend  | Service account credentials (Base64-encoded)      |
 | `GOOGLE_TOKEN_JSON`      | Backend  | Optional OAuth token (Base64-encoded)             |
 | `GOOGLE_CLIENT_ID`       | Both     | Google OAuth client ID                            |

--- a/agents/codex_agent.py
+++ b/agents/codex_agent.py
@@ -7,6 +7,7 @@
 import os
 from typing import Dict, Any, Optional, Tuple, AsyncGenerator
 from openai import AsyncOpenAI, OpenAIError
+from utils.openai_client import create_openai_client
 from utils.patch_utils import validate_patch_format
 from core.logging import log_event
 from dotenv import load_dotenv
@@ -14,7 +15,7 @@ from agents.critic_agent import run_critics
 
 load_dotenv()
 
-client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = create_openai_client()
 
 # === CodexAgent Main Handler ===
 async def handle(message: str, context: str, user_id: Optional[str] = None) -> Dict[str, Any]:

--- a/agents/docs_agent.py
+++ b/agents/docs_agent.py
@@ -7,8 +7,9 @@ import traceback
 from openai import AsyncOpenAI, OpenAIError
 from agents.critic_agent import run_critics
 from core.logging import log_event
+from utils.openai_client import create_openai_client
 
-client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = create_openai_client()
 
 # === System Prompt ===
 SYSTEM_PROMPT = """

--- a/agents/echo_agent.py
+++ b/agents/echo_agent.py
@@ -5,9 +5,10 @@
 import os
 from openai import AsyncOpenAI, OpenAIError
 from core.logging import log_event
+from utils.openai_client import create_openai_client
 
 MODEL = os.getenv("ECHO_MODEL", "gpt-4o")
-openai = AsyncOpenAI()
+openai = create_openai_client()
 
 SYSTEM_PROMPT = """
 You are Echo, the default AI agent in a multi-agent relay system.

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -8,10 +8,11 @@ import traceback
 from openai import AsyncOpenAI, OpenAIError
 from core.logging import log_event
 from agents.critic_agent import run_critics
+from utils.openai_client import create_openai_client
 
 # === Model Configuration ===
 MODEL = os.getenv("PLANNER_MODEL", "gpt-4o")
-openai = AsyncOpenAI()
+openai = create_openai_client()
 
 # === System Prompt: Define role and structure for planner output ===
 SYSTEM_PROMPT = """

--- a/routes/ask.py
+++ b/routes/ask.py
@@ -11,6 +11,7 @@ from typing import Optional
 from agents.codex_agent import handle as codex_agent
 from agents import planner_agent
 from openai import AsyncOpenAI, OpenAIError
+from utils.openai_client import create_openai_client
 from fastapi.responses import StreamingResponse
 from agents.codex_agent import stream as codex_stream
 
@@ -117,7 +118,7 @@ async def ask_codex_stream(
 @router.get("/test_openai")
 async def test_openai():
     try:
-        client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        client = create_openai_client()
         response = await client.chat.completions.create(
             model="gpt-4o",
             messages=[

--- a/services/agent.py
+++ b/services/agent.py
@@ -11,9 +11,10 @@ from openai import AsyncOpenAI
 import services.kb as kb
 import httpx
 from services.context_engine import ContextEngine
+from utils.openai_client import create_openai_client
 
 # === Initialize OpenAI client ===
-client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = create_openai_client()
 
 # === Railway control endpoint for queueing actions/docs ===
 RAILWAY_KEY = os.getenv("API_KEY")

--- a/services/summarize_memory.py
+++ b/services/summarize_memory.py
@@ -4,8 +4,9 @@
 
 import os
 from openai import AsyncOpenAI
+from utils.openai_client import create_openai_client
 
-client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = create_openai_client()
 
 async def summarize_memory_entry(question: str, response: str, context: str = "") -> str:
     prompt = f"""

--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -1,0 +1,16 @@
+# File: utils/openai_client.py
+# Directory: utils/
+# Purpose: Helper to configure AsyncOpenAI with timeout and retry settings.
+
+import os
+import httpx
+from openai import AsyncOpenAI
+
+
+def create_openai_client() -> AsyncOpenAI:
+    """Return a configured AsyncOpenAI client using env vars."""
+    timeout = float(os.getenv("OPENAI_TIMEOUT", "30"))
+    retries = int(os.getenv("OPENAI_MAX_RETRIES", "2"))
+    transport = httpx.AsyncHTTPTransport(retries=retries)
+    http_client = httpx.AsyncClient(timeout=timeout, transport=transport)
+    return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"), http_client=http_client)


### PR DESCRIPTION
## Summary
- centralize AsyncOpenAI creation with configurable timeout and retries
- use new helper in agent and ask routes
- update other agents and utilities to use the helper
- document `OPENAI_TIMEOUT` and `OPENAI_MAX_RETRIES` env vars
- update `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'neo4j')*

------
https://chatgpt.com/codex/tasks/task_e_6862c61877588327be7eddb0dd19f250