### PR TITLE
Wrap SafeMarkdown with prose styling

### DIFF
--- a/frontend/src/app/ask/page.tsx
+++ b/frontend/src/app/ask/page.tsx
@@ -95,7 +95,9 @@ export default function AskPage() {
             }
           >
             <span className="block whitespace-pre-wrap">
-              <SafeMarkdown>{toMDString(msg.content)}</SafeMarkdown>
+              <div className="prose prose-neutral dark:prose-invert max-w-none">
+                <SafeMarkdown>{toMDString(msg.content)}</SafeMarkdown>
+              </div>
             </span>
           </div>
         ))}

--- a/frontend/src/app/codex/page.tsx
+++ b/frontend/src/app/codex/page.tsx
@@ -101,7 +101,9 @@ const CodexPage: React.FC = () => {
           <Button onClick={applyPatch}>✅ Approve & Apply Patch</Button>
           {status && (
             <div className="text-sm text-muted-foreground">
-              <SafeMarkdown>{toMDString(status)}</SafeMarkdown>
+              <div className="prose prose-neutral dark:prose-invert max-w-none">
+                <SafeMarkdown>{toMDString(status)}</SafeMarkdown>
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/app/editor/puck.config.tsx
+++ b/frontend/src/app/editor/puck.config.tsx
@@ -70,7 +70,9 @@ const MarkdownBlock: React.FC<{ title?: string, content: string, imageUrl?: stri
           style={{ maxHeight: "320px", objectFit: "contain" }}
         />
       )}
-      <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
+      <div className="prose prose-neutral dark:prose-invert max-w-none">
+        <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
+++ b/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
@@ -136,7 +136,9 @@ export default function ActionQueuePanel() {
             {a.action.rationale && (
               <div className="text-xs text-blue-800 mt-1 italic">
                 <strong>Why?</strong>{" "}
-                <SafeMarkdown>{toMDString(a.action.rationale)}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{toMDString(a.action.rationale)}</SafeMarkdown>
+                </div>
               </div>
             )}
 
@@ -144,12 +146,16 @@ export default function ActionQueuePanel() {
               <details>
                 <summary className="cursor-pointer text-xs text-blue-700">View Diff</summary>
                 <div className="bg-muted p-2 rounded text-xs overflow-auto whitespace-pre-wrap">
-                  <SafeMarkdown>{toMDString(a.action.diff)}</SafeMarkdown>
+                  <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    <SafeMarkdown>{toMDString(a.action.diff)}</SafeMarkdown>
+                  </div>
                 </div>
               </details>
             ) : (
               <div className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">
-                <SafeMarkdown>{toMDString(a.action.content?.slice(0, 500) || "No content")}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{toMDString(a.action.content?.slice(0, 500) || "No content")}</SafeMarkdown>
+                </div>
               </div>
             )}
 
@@ -166,7 +172,9 @@ export default function ActionQueuePanel() {
 
             {showContext[a.id] && a.action.context && (
               <div className="bg-gray-100 p-2 rounded text-xs max-h-32 overflow-auto mt-2">
-                <SafeMarkdown>{toMDString(a.action.context)}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{toMDString(a.action.context)}</SafeMarkdown>
+                </div>
               </div>
             )}
 
@@ -189,11 +197,13 @@ export default function ActionQueuePanel() {
                 <details>
                   <summary className="cursor-pointer text-xs text-blue-700 mt-1">Show Context Diff</summary>
                   <div className="bg-yellow-100 p-2 rounded text-xs overflow-auto whitespace-pre-wrap">
-                    <SafeMarkdown>
-                      {toMDString(
-                        diffContext(a.action.context, getActionById(compareContextId)?.action.context || "")
-                      )}
-                    </SafeMarkdown>
+                    <div className="prose prose-neutral dark:prose-invert max-w-none">
+                      <SafeMarkdown>
+                        {toMDString(
+                          diffContext(a.action.context, getActionById(compareContextId)?.action.context || "")
+                        )}
+                      </SafeMarkdown>
+                    </div>
                   </div>
                 </details>
               )}
@@ -216,7 +226,9 @@ export default function ActionQueuePanel() {
                     {h.user && <span className="ml-2 text-blue-700">{h.user}</span>}
                     {h.comment && (
                       <span className="ml-2 italic">
-                        <SafeMarkdown>{toMDString(h.comment)}</SafeMarkdown>
+                        <div className="prose prose-neutral dark:prose-invert max-w-none">
+                          <SafeMarkdown>{toMDString(h.comment)}</SafeMarkdown>
+                        </div>
                       </span>
                     )}
                   </li>

--- a/frontend/src/components/AskAgent/ChatMessage.tsx
+++ b/frontend/src/components/AskAgent/ChatMessage.tsx
@@ -17,7 +17,9 @@ export default function ChatMessage({ role, content }: Props) {
 
   return (
     <div className={alignClass}>
-      <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
+      <div className="prose prose-neutral dark:prose-invert max-w-none">
+        <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/AuditPanel/AuditPanel.tsx
+++ b/frontend/src/components/AuditPanel/AuditPanel.tsx
@@ -208,7 +208,11 @@ export default function AuditPanel() {
                 <td className="px-2 py-1 font-mono">{entry.path || ""}</td>
                 <td className="px-2 py-1 font-mono">{entry.id.slice(0, 8)}</td>
                 <td className="px-2 py-1">
-                  {entry.comment ? <SafeMarkdown>{entry.comment}</SafeMarkdown> : ""}
+                  {entry.comment ? (
+                    <div className="prose prose-neutral dark:prose-invert max-w-none">
+                      <SafeMarkdown>{entry.comment}</SafeMarkdown>
+                    </div>
+                  ) : ""}
                 </td>
               </tr>
             ))}
@@ -237,28 +241,39 @@ export default function AuditPanel() {
               <strong>Type:</strong> {selected.type}<br />
               <strong>Path:</strong> {selected.path}<br />
               <strong>Comment:</strong>{" "}
-              {selected.comment ? <SafeMarkdown>{selected.comment}</SafeMarkdown> : ""}<br />
+              {selected.comment ? (
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{selected.comment}</SafeMarkdown>
+                </div>
+              ) : ""}
+              <br />
               <strong>Timestamp:</strong> {selected.timestamp}
             </div>
             {relatedAction?.action?.context && (
               <details>
                 <summary className="cursor-pointer text-blue-700 mb-2">View Agent Context</summary>
                 <div className="bg-gray-50 p-2 rounded text-xs max-h-40 overflow-auto whitespace-pre-wrap">
-                  <SafeMarkdown>{relatedAction.action.context}</SafeMarkdown>
+                  <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    <SafeMarkdown>{relatedAction.action.context}</SafeMarkdown>
+                  </div>
                 </div>
               </details>
             )}
             {relatedAction?.action?.rationale && (
               <div className="text-xs italic mb-2">
                 <strong>Agent rationale:</strong>{" "}
-                <SafeMarkdown>{relatedAction.action.rationale}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{relatedAction.action.rationale}</SafeMarkdown>
+                </div>
               </div>
             )}
             {relatedAction?.action?.diff && (
               <details>
                 <summary className="cursor-pointer text-blue-700 mb-2">View Diff</summary>
                 <div className="bg-yellow-50 p-2 rounded text-xs max-h-40 overflow-auto whitespace-pre-wrap">
-                  <SafeMarkdown>{relatedAction.action.diff}</SafeMarkdown>
+                  <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    <SafeMarkdown>{relatedAction.action.diff}</SafeMarkdown>
+                  </div>
                 </div>
               </details>
             )}
@@ -272,7 +287,9 @@ export default function AuditPanel() {
                       {h.user && <span className="ml-2 text-blue-700">{h.user}</span>}
                       {h.comment && (
                         <span className="ml-2 italic">
-                          <SafeMarkdown>{h.comment}</SafeMarkdown>
+                          <div className="prose prose-neutral dark:prose-invert max-w-none">
+                            <SafeMarkdown>{h.comment}</SafeMarkdown>
+                          </div>
                         </span>
                       )}
                     </li>

--- a/frontend/src/components/Codex/CodexPatchView.tsx
+++ b/frontend/src/components/Codex/CodexPatchView.tsx
@@ -27,7 +27,9 @@ export default function CodexPatchView({ patch, loading = false }: Props) {
         {loading ? (
           "⏳ Codex is generating your patch..."
         ) : patch?.trim() ? (
-          <SafeMarkdown>{patch}</SafeMarkdown>
+          <div className="prose prose-neutral dark:prose-invert max-w-none">
+            <SafeMarkdown>{patch}</SafeMarkdown>
+          </div>
         ) : (
           "No patch yet."
         )}

--- a/frontend/src/components/DocsSyncPanel.tsx
+++ b/frontend/src/components/DocsSyncPanel.tsx
@@ -101,7 +101,9 @@ export default function DocsSyncPanel() {
       {/* Status messages rendered as markdown */}
       {status && (
         <div className="mt-2 text-sm text-muted-foreground">
-          <SafeMarkdown>{status}</SafeMarkdown>
+          <div className="prose prose-neutral dark:prose-invert max-w-none">
+            <SafeMarkdown>{status}</SafeMarkdown>
+          </div>
         </div>
       )}
 
@@ -129,7 +131,9 @@ export default function DocsSyncPanel() {
         </Button>
         {reindexStatus && (
           <div className={`mt-1 text-sm ${reindexStatus.startsWith("✅") ? "text-green-600" : "text-red-500"}`}>
-            <SafeMarkdown>{reindexStatus}</SafeMarkdown>
+            <div className="prose prose-neutral dark:prose-invert max-w-none">
+              <SafeMarkdown>{reindexStatus}</SafeMarkdown>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/DocsViewer/DocsViewer.tsx
+++ b/frontend/src/components/DocsViewer/DocsViewer.tsx
@@ -247,9 +247,13 @@ export default function DocsViewer() {
           <div className="col-span-3">
             <h2 className="font-semibold mb-2">{activeDoc || "Select a document"}</h2>
             <div className="h-[400px] overflow-auto border rounded-md p-4 whitespace-pre-wrap text-sm bg-background">
-              {content
-                ? <SafeMarkdown>{content}</SafeMarkdown>
-                : "Select a document to view its content."}
+              {content ? (
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{content}</SafeMarkdown>
+                </div>
+              ) : (
+                "Select a document to view its content."
+              )}
             </div>
           </div>
         </div>
@@ -290,7 +294,9 @@ export default function DocsViewer() {
               <div>
                 <div className="font-bold mb-2">{hits[selectedHit].file || "Semantic Snippet"}</div>
                 <div className="bg-gray-100 p-3 rounded max-h-[70vh] overflow-y-auto whitespace-pre-wrap text-xs">
-                  <SafeMarkdown>{hits[selectedHit].snippet}</SafeMarkdown>
+                  <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    <SafeMarkdown>{hits[selectedHit].snippet}</SafeMarkdown>
+                  </div>
                 </div>
                 <div className="text-xs text-gray-500 mt-2">
                   Score: {hits[selectedHit].score?.toFixed(2) || "N/A"} | Type: {hits[selectedHit].type || "?"}
@@ -323,7 +329,11 @@ export default function DocsViewer() {
             {ctxLoading
               ? "Fetching context…"
               : ctxResult
-                ? <SafeMarkdown>{ctxResult}</SafeMarkdown>
+                ? (
+                    <div className="prose prose-neutral dark:prose-invert max-w-none">
+                      <SafeMarkdown>{ctxResult}</SafeMarkdown>
+                    </div>
+                  )
                 : "Enter a prompt to see what context the agent would use."}
           </div>
         </div>

--- a/frontend/src/components/GmailOps/GmailOpsPanel.tsx
+++ b/frontend/src/components/GmailOps/GmailOpsPanel.tsx
@@ -50,7 +50,9 @@ export default function GmailOpsPanel() {
         <Button onClick={send}>Send Email</Button>
         {msg && (
           <div className="text-xs mt-2">
-            <SafeMarkdown>{msg}</SafeMarkdown>
+            <div className="prose prose-neutral dark:prose-invert max-w-none">
+              <SafeMarkdown>{msg}</SafeMarkdown>
+            </div>
           </div>
         )}
       </div>
@@ -64,7 +66,9 @@ export default function GmailOpsPanel() {
               <div><strong>Subject:</strong> {em.subject}</div>
               <div><strong>Date:</strong> {em.date}</div>
               <div className="text-gray-500">
-                <SafeMarkdown>{em.snippet}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{em.snippet}</SafeMarkdown>
+                </div>
               </div>
             </li>
           ))}

--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -140,7 +140,9 @@ export default function LogsPanel() {
                 Otherwise, pretty-print as JSON. */}
             {typeof entry.result === "string" ? (
               <div className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">
-                <SafeMarkdown>{entry.result}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{entry.result}</SafeMarkdown>
+                </div>
               </div>
             ) : entry.result ? (
               <pre className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">

--- a/frontend/src/components/MemoryPanel.tsx
+++ b/frontend/src/components/MemoryPanel.tsx
@@ -254,7 +254,9 @@ export default function MemoryPanel() {
             {/* Markdown/code for memory summary */}
             {typeof m.summary === "string" && !!m.summary.trim() && (
               <div className="bg-muted p-2 rounded text-xs whitespace-pre-wrap">
-                <SafeMarkdown>{m.summary}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{m.summary}</SafeMarkdown>
+                </div>
               </div>
             )}
 
@@ -262,7 +264,9 @@ export default function MemoryPanel() {
             {typeof m.agent_response === "string" && !!m.agent_response.trim() && (
               <div className="bg-muted p-2 rounded text-xs whitespace-pre-wrap mt-2">
                 <strong>Agent Response:</strong>
-                <SafeMarkdown>{m.agent_response}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{m.agent_response}</SafeMarkdown>
+                </div>
               </div>
             )}
 
@@ -326,7 +330,9 @@ export default function MemoryPanel() {
           <div className="bg-white rounded shadow-lg max-w-2xl w-full p-6 relative">
             <div className="text-sm mb-2 font-bold">Context File: <code>{modalContext.path}</code></div>
             <div className="bg-gray-100 p-4 rounded max-h-[400px] overflow-auto text-xs">
-              <SafeMarkdown>{modalContext.content}</SafeMarkdown>
+              <div className="prose prose-neutral dark:prose-invert max-w-none">
+                <SafeMarkdown>{modalContext.content}</SafeMarkdown>
+              </div>
             </div>
             <Button variant="secondary" onClick={() => setModalContext(null)} className="absolute top-2 right-2">
               Close

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -138,7 +138,9 @@ export default function SearchPanel() {
                 <strong>{r.title}</strong> ({r.similarity.toFixed(2)})
               </header>
               <div className="mb-1">
-                <SafeMarkdown>{r.snippet}</SafeMarkdown>
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <SafeMarkdown>{r.snippet}</SafeMarkdown>
+                </div>
               </div>
               <footer className="text-xs text-muted-foreground">
                 Updated: {r.updated || "—"}

--- a/frontend/src/components/ui/AskAgent/AskAgent.tsx
+++ b/frontend/src/components/ui/AskAgent/AskAgent.tsx
@@ -45,7 +45,9 @@ export default function AskAgent() {
       </Button>
       {response && (
         <div className="bg-muted p-4 rounded text-sm whitespace-pre-wrap border">
-          <SafeMarkdown>{response}</SafeMarkdown>
+          <div className="prose prose-neutral dark:prose-invert max-w-none">
+            <SafeMarkdown>{response}</SafeMarkdown>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- wrap all `<SafeMarkdown>` usages with a `prose` container for consistent typography

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641f9070a08327b1e33c627ea29f2d