### PR TITLE
Ensure markdown fields sanitized on load

### DIFF
--- a/frontend/src/app/ask/page.tsx
+++ b/frontend/src/app/ask/page.tsx
@@ -20,7 +20,19 @@ export default function AskPage() {
   const [messages, setMessages] = useState<Message[]>(() => {
     if (typeof window !== "undefined") {
       const raw = localStorage.getItem(STORAGE_KEY);
-      return raw ? JSON.parse(raw) : [];
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            return parsed.map((m: any) => ({
+              ...m,
+              content: toMDString(m.content)
+            }));
+          }
+        } catch {
+          return [];
+        }
+      }
     }
     return [];
   });

--- a/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
+++ b/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
@@ -64,7 +64,23 @@ export default function ActionQueuePanel() {
       });
       if (!res.ok) throw new Error("Bad response");
       const data = await res.json();
-      setActions(data.actions || []);
+      const mapped = (data.actions || []).map((a: Action) => ({
+        ...a,
+        action: {
+          ...a.action,
+          rationale: toMDString(a.action?.rationale),
+          diff: toMDString(a.action?.diff),
+          context: toMDString(a.action?.context),
+          content: toMDString(a.action?.content)
+        },
+        history: Array.isArray(a.history)
+          ? a.history.map(h => ({
+              ...h,
+              comment: toMDString(h.comment)
+            }))
+          : a.history
+      }));
+      setActions(mapped);
     } catch (err) {
       console.error("Queue fetch failed", err);
       setError("Failed to fetch action queue.");

--- a/frontend/src/components/AskAgent/hooks.ts
+++ b/frontend/src/components/AskAgent/hooks.ts
@@ -35,7 +35,7 @@ export function useAskAgent(userId: string) {
     if (!query.trim()) return;
 
     // Add user message
-    setMessages((prev) => [...prev, { user: query, agent: "" }]);
+    setMessages((prev) => [...prev, { user: toMDString(query), agent: "" }]);
     setLoading(true);
 
     try {
@@ -84,7 +84,7 @@ export function useAskAgent(userId: string) {
     } catch {
       setMessages((prev) => [
         ...prev.slice(0, -1),
-        { user: query, agent: "Error contacting Relay." },
+        { user: toMDString(query), agent: toMDString("Error contacting Relay.") },
       ]);
     } finally {
       setLoading(false);

--- a/frontend/src/components/AskAgent/useAskEcho.ts
+++ b/frontend/src/components/AskAgent/useAskEcho.ts
@@ -35,7 +35,22 @@ export function useAskEcho() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) setMessages(JSON.parse(raw));
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            setMessages(
+              parsed.map(m => ({
+                ...m,
+                content: toMDString((m as any).content),
+                context: toMDString((m as any).context)
+              }))
+            );
+          }
+        } catch {
+          setMessages([]);
+        }
+      }
     }
   }, []);
 
@@ -87,7 +102,7 @@ export function useAskEcho() {
     if (!input.trim() || loading) return;
 
     const userMessage = input;
-    setMessages((msgs) => [...msgs, { role: "user", content: userMessage }]);
+    setMessages((msgs) => [...msgs, { role: "user", content: toMDString(userMessage) }]);
     setInput("");
     setLoading(true);
 
@@ -139,7 +154,7 @@ export function useAskEcho() {
     } catch {
       setMessages((msgs) => [
         ...msgs,
-        { role: "assistant", content: "[error] Unable to get response." },
+        { role: "assistant", content: toMDString("[error] Unable to get response.") },
       ]);
     }
 

--- a/frontend/src/components/AuditPanel/AuditPanel.tsx
+++ b/frontend/src/components/AuditPanel/AuditPanel.tsx
@@ -52,7 +52,12 @@ export default function AuditPanel() {
       });
       if (!res.ok) throw new Error("Bad response");
       const data = await res.json();
-      setLogs(data.log || []);
+      const mapped = (data.log || []).map((l: LogEntry) => ({
+        ...l,
+        comment: toMDString((l as any).comment),
+        result: toMDString((l as any).result)
+      }));
+      setLogs(mapped);
     } catch (err) {
       console.error("[AuditPanel] Failed to fetch logs:", err);
       setLogs([]);
@@ -68,7 +73,24 @@ export default function AuditPanel() {
       if (!res.ok) throw new Error("Bad response");
       const data = await res.json();
       const action: ActionDetail | undefined = (data.actions as ActionDetail[] | undefined)?.find(a => a.id === id);
-      setRelatedAction(action || null);
+      const mapped = action
+        ? {
+            ...action,
+            action: {
+              ...action.action,
+              context: toMDString(action.action?.context),
+              rationale: toMDString(action.action?.rationale),
+              diff: toMDString(action.action?.diff)
+            },
+            history: Array.isArray(action.history)
+              ? action.history.map(h => ({
+                  ...h,
+                  comment: toMDString(h.comment)
+                }))
+              : action.history
+          }
+        : null;
+      setRelatedAction(mapped);
     } catch (err) {
       console.error("[AuditPanel] Failed to fetch related action:", err);
       setRelatedAction(null);

--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -32,7 +32,11 @@ export default function LogsPanel() {
       }
     });
     const data = await res.json();
-    setLog(data.log || []);
+    const mapped = (data.log || []).map((entry: LogEntry) => ({
+      ...entry,
+      result: toMDString(entry.result as any)
+    }));
+    setLog(mapped);
   }
 
   function downloadJSON() {


### PR DESCRIPTION
## Summary
- sanitize queue actions when loading
- sanitize audit log and related actions
- sanitize execution logs
- ensure all chat state updates stringify via `toMDString`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_686420cd04a88327885c08dd6d7caee7