### PR TITLE
Handle non-string input in SafeMarkdown

### DIFF
--- a/frontend/src/components/SafeMarkdown.tsx
+++ b/frontend/src/components/SafeMarkdown.tsx
@@ -50,12 +50,25 @@ const markdownComponents: Components = {
 };
 
 export default function SafeMarkdown({ children, className }: SafeMarkdownProps) {
+  // Warn if something other than a string is passed. This helps catch mistakes
+  // where a React element or other type might slip through and break rendering.
+  if (typeof children !== "string") {
+    console.warn(
+      "SafeMarkdown expected string, got",
+      typeof children,
+      children
+    );
+  }
+
+  const strChildren =
+    typeof children === "string" ? children : children ? String(children) : "";
+
   // Ultra-safe: Escape anything that looks like raw HTML, even before markdown parsing
   // This is a belt-and-suspenders approach since skipHtml and disallowedElements are also set
-  const likelyRawHtml = /<\s*[a-zA-Z]+[^>]*>/.test(children);
+  const likelyRawHtml = /<\s*[a-zA-Z]+[^>]*>/.test(strChildren);
   const safeChildren = likelyRawHtml
-    ? children.replace(/</g, "&lt;").replace(/>/g, "&gt;")
-    : children;
+    ? strChildren.replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    : strChildren;
 
   return (
     <ReactMarkdown


### PR DESCRIPTION
## Summary
- warn when `SafeMarkdown` receives a non-string child
- coerce child to string before sanitizing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: neo4j, httpx, openai)*
- `npm run lint` in `frontend` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642224b09c83279b91a918e31df0ea