### PR TITLE
Add frontend unit tests for toMDString and SafeMarkdown

### DIFF
--- a/frontend/tests/SafeMarkdown.test.tsx
+++ b/frontend/tests/SafeMarkdown.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import SafeMarkdown from '../src/components/SafeMarkdown';
+
+describe('SafeMarkdown', () => {
+  it('renders markdown strings without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const html = renderToStaticMarkup(<SafeMarkdown>**bold**</SafeMarkdown>);
+    expect(html).toContain('<strong>bold</strong>');
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('warns when non-string is provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const html = renderToStaticMarkup(
+      <SafeMarkdown>{123 as any}</SafeMarkdown>
+    );
+    expect(html).toContain('123');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/frontend/tests/toMDString.test.ts
+++ b/frontend/tests/toMDString.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import toMDString from '../src/lib/toMDString';
+
+describe('toMDString', () => {
+  it('converts primitives to strings', () => {
+    expect(toMDString('hello')).toBe('hello');
+    expect(toMDString(42)).toBe('42');
+    expect(toMDString(true)).toBe('true');
+    expect(toMDString(null)).toBe('');
+    expect(toMDString(undefined)).toBe('');
+  });
+
+  it('joins arrays with newlines', () => {
+    expect(toMDString(['a', 1, false])).toBe('a\n1\nfalse');
+  });
+
+  it('formats objects as fenced JSON', () => {
+    const obj = { a: 1, b: 'two' };
+    const expected = '```json\n' + JSON.stringify(obj, null, 2) + '\n```';
+    expect(toMDString(obj)).toBe(expected);
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -30,6 +30,13 @@ export default defineConfig({
           setupFiles: ['.storybook/vitest.setup.ts'],
         },
       },
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary
- add vitest unit tests under `frontend/tests`
- verify `toMDString` handles primitives, arrays and objects
- test `<SafeMarkdown>` warnings for invalid props
- run unit tests via new workspace in vitest config

## Testing
- `npx vitest run` *(fails: 403 Forbidden to download vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6864245b02d88327884bec6bda507bcb