### PR TITLE
Fix markdown coercion and imports

### DIFF
--- a/frontend/src/components/GmailOps/GmailOpsPanel.tsx
+++ b/frontend/src/components/GmailOps/GmailOpsPanel.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { API_ROOT } from "@/lib/api";
 import SafeMarkdown from "@/components/SafeMarkdown";
+import { toMDString } from "@/lib/toMDString";
 
 // Explicitly type the Email shape
 type Email = {
@@ -29,7 +30,11 @@ export default function GmailOpsPanel() {
       body: JSON.stringify({ to_email: to, subject, body })
     });
     const data = await res.json();
-    setMsg(data.status === "sent" ? "Email sent!" : `Failed: ${data.detail}`);
+    setMsg(
+      toMDString(
+        data.status === "sent" ? "Email sent!" : `Failed: ${data.detail}`
+      )
+    );
   }
 
   async function list() {
@@ -37,7 +42,13 @@ export default function GmailOpsPanel() {
       headers: { "X-API-Key": process.env.NEXT_PUBLIC_API_KEY || "" }
     });
     const data = await res.json();
-    setEmails((data.emails as Email[]) || []);
+    const mapped = Array.isArray(data.emails)
+      ? (data.emails as Email[]).map((em) => ({
+          ...em,
+          snippet: toMDString(em.snippet),
+        }))
+      : [];
+    setEmails(mapped);
   }
 
   return (

--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { API_ROOT } from "@/lib/api";
 import SafeMarkdown from "@/components/SafeMarkdown";
+import { toMDString } from "@/lib/toMDString";
 
 interface LogEntry {
   id: string;

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { API_ROOT, API_KEY } from "@/lib/api";
 import SafeMarkdown from "@/components/SafeMarkdown";
+import { toMDString } from "@/lib/toMDString";
 
 export type KBResult = {
   path: string;
@@ -77,7 +78,11 @@ export default function SearchPanel() {
       }
 
       const data: KBResult[] = await res.json();
-      setResults(data);
+      const mapped = data.map((r) => ({
+        ...r,
+        snippet: toMDString(r.snippet),
+      }));
+      setResults(mapped);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {
         return; // request was cancelled


### PR DESCRIPTION
## Summary
- ensure logs panel imports `toMDString`
- coerce email snippets and messages to markdown strings
- coerce KB search results before storing

## Testing
- `npx vitest run --silent` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68641d8136d8832781e8aab59b0eb084