### PR TITLE
Fix lint warnings for any and img usage

### DIFF
--- a/frontend/src/app/ask/page.tsx
+++ b/frontend/src/app/ask/page.tsx
@@ -24,9 +24,9 @@ export default function AskPage() {
         try {
           const parsed = JSON.parse(raw);
           if (Array.isArray(parsed)) {
-            return parsed.map((m: any) => ({
-              ...m,
-              content: toMDString(m.content)
+            return parsed.map((m: unknown) => ({
+              ...(m as Record<string, unknown>),
+              content: toMDString((m as Record<string, unknown>).content)
             }));
           }
         } catch {

--- a/frontend/src/app/editor/puck.config.tsx
+++ b/frontend/src/app/editor/puck.config.tsx
@@ -22,6 +22,7 @@ import { Textarea } from '../../components/ui/textarea'
 
 import SafeMarkdown from "@/components/SafeMarkdown";
 import React from "react";
+import Image from "next/image";
 import { toMDString } from "@/lib/toMDString";
 
 // use shared markdown helper
@@ -62,10 +63,11 @@ const MarkdownBlock: React.FC<{ title?: string, content: string, imageUrl?: stri
     <div className="prose prose-neutral dark:prose-invert max-w-none border rounded-xl p-4 bg-background shadow mb-4">
       {title && <h2>{title}</h2>}
       {imageUrl && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
+        <Image
           src={imageUrl}
           alt={title || "Markdown image"}
+          width={320}
+          height={320}
           className="rounded-lg my-4 max-w-full"
           style={{ maxHeight: "320px", objectFit: "contain" }}
         />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { Render } from '@measured/puck'
 import '@measured/puck/puck.css'
 import config from '@/app/editor/puck.config'
@@ -24,9 +25,11 @@ export default function Home() {
       {/* Echo - Strategist (top-right corner) */}
       <div className="absolute top-4 right-4 bg-black/90 text-white rounded-xl shadow-2xl p-4 max-w-xs z-50 backdrop-blur-sm">
         <div className="flex items-center gap-4">
-          <img
+          <Image
             src="/Echo.png"
             alt="Echo"
+            width={48}
+            height={48}
             className="w-12 h-12 rounded-md border border-white shadow-md"
           />
           <div className="text-sm leading-snug">

--- a/frontend/src/components/AskAgent/useAskEcho.ts
+++ b/frontend/src/components/AskAgent/useAskEcho.ts
@@ -41,9 +41,9 @@ export function useAskEcho() {
           if (Array.isArray(parsed)) {
             setMessages(
               parsed.map(m => ({
-                ...m,
-                content: toMDString((m as any).content),
-                context: toMDString((m as any).context)
+                ...m as Record<string, unknown>,
+                content: toMDString((m as Record<string, unknown>).content),
+                context: toMDString((m as Record<string, unknown>).context)
               }))
             );
           }

--- a/frontend/src/components/AuditPanel/AuditPanel.tsx
+++ b/frontend/src/components/AuditPanel/AuditPanel.tsx
@@ -54,8 +54,8 @@ export default function AuditPanel() {
       const data = await res.json();
       const mapped = (data.log || []).map((l: LogEntry) => ({
         ...l,
-        comment: toMDString((l as any).comment),
-        result: toMDString((l as any).result)
+        comment: toMDString(l.comment),
+        result: toMDString(l.result)
       }));
       setLogs(mapped);
     } catch (err) {

--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -35,7 +35,7 @@ export default function LogsPanel() {
     const data = await res.json();
     const mapped = (data.log || []).map((entry: LogEntry) => ({
       ...entry,
-      result: toMDString(entry.result as any)
+      result: toMDString(entry.result)
     }));
     setLog(mapped);
   }

--- a/frontend/tests/SafeMarkdown.test.tsx
+++ b/frontend/tests/SafeMarkdown.test.tsx
@@ -15,7 +15,7 @@ describe('SafeMarkdown', () => {
   it('warns when non-string is provided', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const html = renderToStaticMarkup(
-      <SafeMarkdown>{123 as any}</SafeMarkdown>
+      <SafeMarkdown>{123 as unknown as string}</SafeMarkdown>
     );
     expect(html).toContain('123');
     expect(warn).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- replace `any` casts with safer `unknown` handling
- convert `<img>` elements to Next.js `<Image/>`

## Testing
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686431697ca8832787f218d5c61a3285