### PR TITLE
Ensure markdown safety via toMDString helper

### DIFF
--- a/frontend/src/app/ask/page.tsx
+++ b/frontend/src/app/ask/page.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import SafeMarkdown from "@/components/SafeMarkdown";
 import { API_ROOT } from "@/lib/api";
+import { toMDString } from "@/lib/toMDString";
 
 type Message = {
   role: "user" | "assistant";
@@ -15,17 +16,6 @@ type Message = {
 const USER_ID = "bret-demo";
 const STORAGE_KEY = `echo-chat-history-${USER_ID}`;
 
-// Bulletproof stringifier for all markdown rendering
-function toMDString(val: unknown): string {
-  if (val == null) return "";
-  if (typeof val === "string") return val;
-  if (Array.isArray(val)) return val.map(toMDString).join("\n\n");
-  try {
-    return "```json\n" + JSON.stringify(val, null, 2) + "\n```";
-  } catch {
-    return String(val);
-  }
-}
 
 export default function AskPage() {
   const [messages, setMessages] = useState<Message[]>(() => {

--- a/frontend/src/app/codex/page.tsx
+++ b/frontend/src/app/codex/page.tsx
@@ -64,7 +64,7 @@ const CodexPage: React.FC = () => {
 
   const applyPatch = async (): Promise<void> => {
     if (!parsedPatch) return;
-    setStatus("⏳ Applying patch...");
+    setStatus(toMDString("⏳ Applying patch..."));
 
     try {
       const res = await fetch(`${API_ROOT}/codex/apply_patch`, {
@@ -78,13 +78,13 @@ const CodexPage: React.FC = () => {
       });
 
       if (res.ok) {
-        setStatus("✅ Patch applied successfully.");
+        setStatus(toMDString("✅ Patch applied successfully."));
       } else {
         const err = await res.text();
-        setStatus("❌ Failed to apply patch: " + err);
+        setStatus(toMDString("❌ Failed to apply patch: " + err));
       }
     } catch (err) {
-      setStatus("❌ Patch request failed: " + String(err));
+      setStatus(toMDString("❌ Patch request failed: " + String(err)));
     }
   };
 

--- a/frontend/src/components/DocsSyncPanel.tsx
+++ b/frontend/src/components/DocsSyncPanel.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { API_ROOT } from "@/lib/api";
 import SafeMarkdown from "@/components/SafeMarkdown";
+import { toMDString } from "@/lib/toMDString";
 
 export default function DocsSyncPanel() {
   const [status, setStatus] = useState<string | null>(null);
@@ -24,10 +25,10 @@ export default function DocsSyncPanel() {
    */
   const triggerSync = async (endpoint: string) => {
     if (!API_ROOT) {
-      setStatus("❌ API URL not configured");
+      setStatus(toMDString("❌ API URL not configured"));
       return;
     }
-    setStatus("⏳ Running...");
+    setStatus(toMDString("⏳ Running..."));
     setFiles([]);
     setLoading(true);
     try {
@@ -38,15 +39,15 @@ export default function DocsSyncPanel() {
       const data = await res.json();
       if (Array.isArray(data.synced_docs)) {
         setFiles(data.synced_docs);
-        setStatus(`✅ Synced ${data.synced_docs.length} docs.`);
+        setStatus(toMDString(`✅ Synced ${data.synced_docs.length} docs.`));
       } else if (data.message) {
-        setStatus(`✅ ${data.message}`);
+        setStatus(toMDString(`✅ ${data.message}`));
       } else {
-        setStatus("✅ Operation completed.");
+        setStatus(toMDString("✅ Operation completed."));
       }
     } catch (err) {
       console.error("DocsSync error:", err);
-      setStatus("❌ Failed to sync. See console for details.");
+      setStatus(toMDString("❌ Failed to sync. See console for details."));
     } finally {
       setLoading(false);
     }
@@ -55,10 +56,10 @@ export default function DocsSyncPanel() {
   // --- NEW: Trigger a KB reindex (admin only) ---
   const triggerReindex = async () => {
     if (!API_ROOT) {
-      setReindexStatus("❌ API URL not configured");
+      setReindexStatus(toMDString("❌ API URL not configured"));
       return;
     }
-    setReindexStatus("⏳ Reindexing...");
+    setReindexStatus(toMDString("⏳ Reindexing..."));
     setReindexLoading(true);
     try {
       const res = await fetch(`${API_ROOT}/admin/trigger_reindex`, {
@@ -71,13 +72,13 @@ export default function DocsSyncPanel() {
       });
       const data = await res.json();
       if (res.ok) {
-        setReindexStatus(`✅ ${data.message || "Reindex complete."}`);
+        setReindexStatus(toMDString(`✅ ${data.message || "Reindex complete."}`));
       } else {
-        setReindexStatus(`❌ ${data.detail || "Reindex failed."}`);
+        setReindexStatus(toMDString(`❌ ${data.detail || "Reindex failed."}`));
       }
     } catch (err) {
       console.error("Reindex error:", err);
-      setReindexStatus("❌ Failed to reindex. See console for details.");
+      setReindexStatus(toMDString("❌ Failed to reindex. See console for details."));
     } finally {
       setReindexLoading(false);
     }

--- a/frontend/src/components/MemoryPanel.tsx
+++ b/frontend/src/components/MemoryPanel.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { API_ROOT } from "@/lib/api"
 import SafeMarkdown from "@/components/SafeMarkdown"
+import { toMDString } from "@/lib/toMDString"
 
 interface ContextSource {
   type: string
@@ -70,7 +71,12 @@ export default function MemoryPanel() {
       })
       if (!res.ok) throw new Error(`Status ${res.status}`)
       const data = await res.json()
-      setMemory(data.entries || [])
+      const mapped = (data.entries || []).map((m: any) => ({
+        ...m,
+        summary: toMDString(m.summary),
+        agent_response: toMDString(m.agent_response),
+      }))
+      setMemory(mapped)
       setFetchInfo({ status: "success", time: Date.now() - start, error: "" })
     } catch (e: unknown) {
       const errorMsg = e instanceof Error ? e.message : String(e)

--- a/frontend/src/lib/toMDString.ts
+++ b/frontend/src/lib/toMDString.ts
@@ -2,7 +2,7 @@ export function toMDString(val: unknown): string {
   if (val == null) return "";
   if (typeof val === "string") return val;
   if (Array.isArray(val)) {
-    return val.map(v => toMDString(v)).join("\n");
+    return val.map((v) => toMDString(v)).join("\n\n");
   }
   if (typeof val === "object") {
     try {

--- a/frontend/tests/toMDString.test.ts
+++ b/frontend/tests/toMDString.test.ts
@@ -10,8 +10,8 @@ describe('toMDString', () => {
     expect(toMDString(undefined)).toBe('');
   });
 
-  it('joins arrays with newlines', () => {
-    expect(toMDString(['a', 1, false])).toBe('a\n1\nfalse');
+  it('joins arrays with blank lines', () => {
+    expect(toMDString(['a', 1, false])).toBe('a\n\n1\n\nfalse');
   });
 
   it('formats objects as fenced JSON', () => {


### PR DESCRIPTION
## Summary
- refactor `toMDString` helper to join arrays as separate markdown blocks
- use shared `toMDString` in Ask page and memory fetch logic
- sanitize status strings in DocsSyncPanel and Codex page
- adjust tests for new `toMDString` behavior

## Testing
- `npx vitest run` *(fails: 403 Forbidden - cannot download vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_68643d3d7f648327895381e6249f3d8a