### PR TITLE
Add debug logs for React child types

### DIFF
--- a/frontend/src/app/ask/page.tsx
+++ b/frontend/src/app/ask/page.tsx
@@ -141,6 +141,8 @@ export default function AskPage() {
             }
           >
             <div className="prose prose-neutral dark:prose-invert max-w-none">
+              {typeof msg.content !== "string" &&
+                console.log("DEBUG 418:", typeof msg.content, msg.content)}
               <SafeMarkdown>{msg.content}</SafeMarkdown>
             </div>
           </div>

--- a/frontend/src/app/codex/page.tsx
+++ b/frontend/src/app/codex/page.tsx
@@ -102,6 +102,8 @@ const CodexPage: React.FC = () => {
           {status && (
             <div className="text-sm text-muted-foreground">
               <div className="prose prose-neutral dark:prose-invert max-w-none">
+                {typeof status !== "string" &&
+                  console.log("DEBUG 418:", typeof status, status)}
                 <SafeMarkdown>{toMDString(status)}</SafeMarkdown>
               </div>
             </div>

--- a/frontend/src/app/editor/puck.config.tsx
+++ b/frontend/src/app/editor/puck.config.tsx
@@ -73,6 +73,8 @@ const MarkdownBlock: React.FC<{ title?: string, content: string, imageUrl?: stri
         />
       )}
       <div className="prose prose-neutral dark:prose-invert max-w-none">
+        {typeof content !== "string" &&
+          console.log("DEBUG 418:", typeof content, content)}
         <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
       </div>
     </div>

--- a/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
+++ b/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
@@ -153,6 +153,12 @@ export default function ActionQueuePanel() {
               <div className="text-xs text-blue-800 mt-1 italic">
                 <strong>Why?</strong>{" "}
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof a.action.rationale !== "string" &&
+                    console.log(
+                      "DEBUG 418:",
+                      typeof a.action.rationale,
+                      a.action.rationale
+                    )}
                   <SafeMarkdown>{toMDString(a.action.rationale)}</SafeMarkdown>
                 </div>
               </div>
@@ -163,6 +169,12 @@ export default function ActionQueuePanel() {
                 <summary className="cursor-pointer text-xs text-blue-700">View Diff</summary>
                 <div className="bg-muted p-2 rounded text-xs overflow-auto whitespace-pre-wrap">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    {typeof a.action.diff !== "string" &&
+                      console.log(
+                        "DEBUG 418:",
+                        typeof a.action.diff,
+                        a.action.diff
+                      )}
                     <SafeMarkdown>{toMDString(a.action.diff)}</SafeMarkdown>
                   </div>
                 </div>
@@ -170,6 +182,12 @@ export default function ActionQueuePanel() {
             ) : (
               <div className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof a.action.content !== "string" &&
+                    console.log(
+                      "DEBUG 418:",
+                      typeof a.action.content,
+                      a.action.content
+                    )}
                   <SafeMarkdown>{toMDString(a.action.content?.slice(0, 500) || "No content")}</SafeMarkdown>
                 </div>
               </div>
@@ -189,6 +207,12 @@ export default function ActionQueuePanel() {
             {showContext[a.id] && a.action.context && (
               <div className="bg-gray-100 p-2 rounded text-xs max-h-32 overflow-auto mt-2">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof a.action.context !== "string" &&
+                    console.log(
+                      "DEBUG 418:",
+                      typeof a.action.context,
+                      a.action.context
+                    )}
                   <SafeMarkdown>{toMDString(a.action.context)}</SafeMarkdown>
                 </div>
               </div>
@@ -243,6 +267,12 @@ export default function ActionQueuePanel() {
                     {h.comment && (
                       <span className="ml-2 italic">
                         <div className="prose prose-neutral dark:prose-invert max-w-none">
+                          {typeof h.comment !== "string" &&
+                            console.log(
+                              "DEBUG 418:",
+                              typeof h.comment,
+                              h.comment
+                            )}
                           <SafeMarkdown>{toMDString(h.comment)}</SafeMarkdown>
                         </div>
                       </span>

--- a/frontend/src/components/AskAgent/ChatMessage.tsx
+++ b/frontend/src/components/AskAgent/ChatMessage.tsx
@@ -18,6 +18,8 @@ export default function ChatMessage({ role, content }: Props) {
   return (
     <div className={alignClass}>
       <div className="prose prose-neutral dark:prose-invert max-w-none">
+        {typeof content !== "string" &&
+          console.log("DEBUG 418:", typeof content, content)}
         <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
       </div>
     </div>

--- a/frontend/src/components/AskAgent/ChatWindow.tsx
+++ b/frontend/src/components/AskAgent/ChatWindow.tsx
@@ -28,7 +28,11 @@ export default function ChatWindow() {
       {/* Message List */}
       <div className="flex-1 space-y-2 overflow-y-auto border rounded-xl p-4 bg-muted">
         {messages.map((msg, i) => (
-          <ChatMessage key={i} role={msg.role} content={toMDString(msg.content)} />
+          <>
+            {typeof msg.content !== "string" &&
+              console.log("DEBUG 418:", typeof msg.content, msg.content)}
+            <ChatMessage key={i} role={msg.role} content={toMDString(msg.content)} />
+          </>
         ))}
         {loading && (
           <div className="text-left text-green-700 animate-pulse">

--- a/frontend/src/components/AuditPanel/AuditPanel.tsx
+++ b/frontend/src/components/AuditPanel/AuditPanel.tsx
@@ -245,6 +245,8 @@ export default function AuditPanel() {
                 <td className="px-2 py-1">
                   {entry.comment ? (
                     <div className="prose prose-neutral dark:prose-invert max-w-none">
+                      {typeof entry.comment !== "string" &&
+                        console.log("DEBUG 418:", typeof entry.comment, entry.comment)}
                       <SafeMarkdown>{entry.comment}</SafeMarkdown>
                     </div>
                   ) : ""}
@@ -278,6 +280,12 @@ export default function AuditPanel() {
               <strong>Comment:</strong>{" "}
               {selected.comment ? (
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof selected.comment !== "string" &&
+                    console.log(
+                      "DEBUG 418:",
+                      typeof selected.comment,
+                      selected.comment
+                    )}
                   <SafeMarkdown>{selected.comment}</SafeMarkdown>
                 </div>
               ) : ""}
@@ -289,6 +297,12 @@ export default function AuditPanel() {
                 <summary className="cursor-pointer text-blue-700 mb-2">View Agent Context</summary>
                 <div className="bg-gray-50 p-2 rounded text-xs max-h-40 overflow-auto whitespace-pre-wrap">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    {typeof relatedAction.action.context !== "string" &&
+                      console.log(
+                        "DEBUG 418:",
+                        typeof relatedAction.action.context,
+                        relatedAction.action.context
+                      )}
                     <SafeMarkdown>{relatedAction.action.context}</SafeMarkdown>
                   </div>
                 </div>
@@ -298,6 +312,12 @@ export default function AuditPanel() {
               <div className="text-xs italic mb-2">
                 <strong>Agent rationale:</strong>{" "}
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof relatedAction.action.rationale !== "string" &&
+                    console.log(
+                      "DEBUG 418:",
+                      typeof relatedAction.action.rationale,
+                      relatedAction.action.rationale
+                    )}
                   <SafeMarkdown>{relatedAction.action.rationale}</SafeMarkdown>
                 </div>
               </div>
@@ -307,6 +327,12 @@ export default function AuditPanel() {
                 <summary className="cursor-pointer text-blue-700 mb-2">View Diff</summary>
                 <div className="bg-yellow-50 p-2 rounded text-xs max-h-40 overflow-auto whitespace-pre-wrap">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    {typeof relatedAction.action.diff !== "string" &&
+                      console.log(
+                        "DEBUG 418:",
+                        typeof relatedAction.action.diff,
+                        relatedAction.action.diff
+                      )}
                     <SafeMarkdown>{relatedAction.action.diff}</SafeMarkdown>
                   </div>
                 </div>
@@ -323,6 +349,12 @@ export default function AuditPanel() {
                       {h.comment && (
                         <span className="ml-2 italic">
                           <div className="prose prose-neutral dark:prose-invert max-w-none">
+                            {typeof h.comment !== "string" &&
+                              console.log(
+                                "DEBUG 418:",
+                                typeof h.comment,
+                                h.comment
+                              )}
                             <SafeMarkdown>{h.comment}</SafeMarkdown>
                           </div>
                         </span>

--- a/frontend/src/components/Codex/CodexPatchView.tsx
+++ b/frontend/src/components/Codex/CodexPatchView.tsx
@@ -28,6 +28,8 @@ export default function CodexPatchView({ patch, loading = false }: Props) {
           "⏳ Codex is generating your patch..."
         ) : patch?.trim() ? (
           <div className="prose prose-neutral dark:prose-invert max-w-none">
+            {typeof patch !== "string" &&
+              console.log("DEBUG 418:", typeof patch, patch)}
             <SafeMarkdown>{patch}</SafeMarkdown>
           </div>
         ) : (

--- a/frontend/src/components/DocsSyncPanel.tsx
+++ b/frontend/src/components/DocsSyncPanel.tsx
@@ -103,6 +103,8 @@ export default function DocsSyncPanel() {
       {status && (
         <div className="mt-2 text-sm text-muted-foreground">
           <div className="prose prose-neutral dark:prose-invert max-w-none">
+            {typeof status !== "string" &&
+              console.log("DEBUG 418:", typeof status, status)}
             <SafeMarkdown>{status}</SafeMarkdown>
           </div>
         </div>
@@ -133,6 +135,8 @@ export default function DocsSyncPanel() {
         {reindexStatus && (
           <div className={`mt-1 text-sm ${reindexStatus.startsWith("✅") ? "text-green-600" : "text-red-500"}`}>
             <div className="prose prose-neutral dark:prose-invert max-w-none">
+              {typeof reindexStatus !== "string" &&
+                console.log("DEBUG 418:", typeof reindexStatus, reindexStatus)}
               <SafeMarkdown>{reindexStatus}</SafeMarkdown>
             </div>
           </div>

--- a/frontend/src/components/DocsViewer/DocsViewer.tsx
+++ b/frontend/src/components/DocsViewer/DocsViewer.tsx
@@ -249,6 +249,8 @@ export default function DocsViewer() {
             <div className="h-[400px] overflow-auto border rounded-md p-4 whitespace-pre-wrap text-sm bg-background">
               {content ? (
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof content !== "string" &&
+                    console.log("DEBUG 418:", typeof content, content)}
                   <SafeMarkdown>{content}</SafeMarkdown>
                 </div>
               ) : (
@@ -295,6 +297,12 @@ export default function DocsViewer() {
                 <div className="font-bold mb-2">{hits[selectedHit].file || "Semantic Snippet"}</div>
                 <div className="bg-gray-100 p-3 rounded max-h-[70vh] overflow-y-auto whitespace-pre-wrap text-xs">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
+                    {typeof hits[selectedHit].snippet !== "string" &&
+                      console.log(
+                        "DEBUG 418:",
+                        typeof hits[selectedHit].snippet,
+                        hits[selectedHit].snippet
+                      )}
                     <SafeMarkdown>{hits[selectedHit].snippet}</SafeMarkdown>
                   </div>
                 </div>
@@ -331,7 +339,9 @@ export default function DocsViewer() {
               : ctxResult
                 ? (
                     <div className="prose prose-neutral dark:prose-invert max-w-none">
-                      <SafeMarkdown>{ctxResult}</SafeMarkdown>
+                    {typeof ctxResult !== "string" &&
+                      console.log("DEBUG 418:", typeof ctxResult, ctxResult)}
+                    <SafeMarkdown>{ctxResult}</SafeMarkdown>
                     </div>
                   )
                 : "Enter a prompt to see what context the agent would use."}

--- a/frontend/src/components/GmailOps/GmailOpsPanel.tsx
+++ b/frontend/src/components/GmailOps/GmailOpsPanel.tsx
@@ -62,6 +62,8 @@ export default function GmailOpsPanel() {
         {msg && (
           <div className="text-xs mt-2">
             <div className="prose prose-neutral dark:prose-invert max-w-none">
+              {typeof msg !== "string" &&
+                console.log("DEBUG 418:", typeof msg, msg)}
               <SafeMarkdown>{msg}</SafeMarkdown>
             </div>
           </div>
@@ -78,6 +80,8 @@ export default function GmailOpsPanel() {
               <div><strong>Date:</strong> {em.date}</div>
               <div className="text-gray-500">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof em.snippet !== "string" &&
+                    console.log("DEBUG 418:", typeof em.snippet, em.snippet)}
                   <SafeMarkdown>{em.snippet}</SafeMarkdown>
                 </div>
               </div>

--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -146,6 +146,8 @@ export default function LogsPanel() {
             {typeof entry.result === "string" ? (
               <div className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof entry.result !== "string" &&
+                    console.log("DEBUG 418:", typeof entry.result, entry.result)}
                   <SafeMarkdown>{entry.result}</SafeMarkdown>
                 </div>
               </div>

--- a/frontend/src/components/MemoryPanel.tsx
+++ b/frontend/src/components/MemoryPanel.tsx
@@ -264,6 +264,8 @@ export default function MemoryPanel() {
             {typeof m.summary === "string" && !!m.summary.trim() && (
               <div className="bg-muted p-2 rounded text-xs whitespace-pre-wrap">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof m.summary !== "string" &&
+                    console.log("DEBUG 418:", typeof m.summary, m.summary)}
                   <SafeMarkdown>{m.summary}</SafeMarkdown>
                 </div>
               </div>
@@ -274,6 +276,8 @@ export default function MemoryPanel() {
               <div className="bg-muted p-2 rounded text-xs whitespace-pre-wrap mt-2">
                 <strong>Agent Response:</strong>
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof m.agent_response !== "string" &&
+                    console.log("DEBUG 418:", typeof m.agent_response, m.agent_response)}
                   <SafeMarkdown>{m.agent_response}</SafeMarkdown>
                 </div>
               </div>
@@ -340,6 +344,12 @@ export default function MemoryPanel() {
             <div className="text-sm mb-2 font-bold">Context File: <code>{modalContext.path}</code></div>
             <div className="bg-gray-100 p-4 rounded max-h-[400px] overflow-auto text-xs">
               <div className="prose prose-neutral dark:prose-invert max-w-none">
+                {typeof modalContext.content !== "string" &&
+                  console.log(
+                    "DEBUG 418:",
+                    typeof modalContext.content,
+                    modalContext.content
+                  )}
                 <SafeMarkdown>{modalContext.content}</SafeMarkdown>
               </div>
             </div>

--- a/frontend/src/components/SafeMarkdown.tsx
+++ b/frontend/src/components/SafeMarkdown.tsx
@@ -75,6 +75,8 @@ export default function SafeMarkdown({ children, className }: SafeMarkdownProps)
     : strChildren;
 
   return (
+    {typeof safeChildren !== "string" &&
+      console.log("DEBUG 418:", typeof safeChildren, safeChildren)}
     <ReactMarkdown
       components={markdownComponents}
       // SECURITY: Never allow any HTML passthrough from markdown

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -144,6 +144,8 @@ export default function SearchPanel() {
               </header>
               <div className="mb-1">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  {typeof r.snippet !== "string" &&
+                    console.log("DEBUG 418:", typeof r.snippet, r.snippet)}
                   <SafeMarkdown>{r.snippet}</SafeMarkdown>
                 </div>
               </div>

--- a/frontend/src/components/ui/AskAgent/AskAgent.tsx
+++ b/frontend/src/components/ui/AskAgent/AskAgent.tsx
@@ -46,6 +46,8 @@ export default function AskAgent() {
       {response && (
         <div className="bg-muted p-4 rounded text-sm whitespace-pre-wrap border">
           <div className="prose prose-neutral dark:prose-invert max-w-none">
+            {typeof response !== "string" &&
+              console.log("DEBUG 418:", typeof response, response)}
             <SafeMarkdown>{response}</SafeMarkdown>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- log type of values passed to SafeMarkdown and React components
- log message contents when mapping over chat history

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'neo4j')*

------
https://chatgpt.com/codex/tasks/task_e_68645d0005788327bfa2f20b491e2d9e