### PR TITLE
Remove console logs from JSX

### DIFF
--- a/frontend/src/app/ask/page.tsx
+++ b/frontend/src/app/ask/page.tsx
@@ -126,29 +126,29 @@ export default function AskPage() {
     setLoading(false);
   }, [input, loading]);
 
+  const renderedMessages = messages.map((msg, i) => {
+    if (typeof msg.content !== "string") {
+      console.log("DEBUG 418:", typeof msg.content, msg.content);
+    }
+    return (
+      <div
+        key={i}
+        className={
+          msg.role === "user" ? "text-right text-blue-700" : "text-left text-green-700"
+        }
+      >
+        <div className="prose prose-neutral dark:prose-invert max-w-none">
+          <SafeMarkdown>{msg.content}</SafeMarkdown>
+        </div>
+      </div>
+    );
+  });
+
   return (
     <div className="w-full max-w-2xl mx-auto min-h-screen flex flex-col">
       <h1 className="text-3xl font-bold my-4">Ask Echo</h1>
       <div className="flex-1 space-y-2 overflow-y-auto border rounded-xl p-4 bg-muted">
-        {messages.map((msg, i) => {
-  if (typeof msg.content !== "string") {
-    console.log("DEBUG 418:", typeof msg.content, msg.content);
-  }
-  return (
-    <div
-      key={i}
-      className={
-        msg.role === "user"
-          ? "text-right text-blue-700"
-          : "text-left text-green-700"
-      }
-    >
-      <div className="prose prose-neutral dark:prose-invert max-w-none">
-        <SafeMarkdown>{msg.content}</SafeMarkdown>
-      </div>
-    </div>
-  );
-})}
+        {renderedMessages}
 
         {loading && (
           <div className="text-left text-green-700 animate-pulse">

--- a/frontend/src/app/codex/page.tsx
+++ b/frontend/src/app/codex/page.tsx
@@ -88,6 +88,10 @@ const CodexPage: React.FC = () => {
     }
   };
 
+  if (typeof status !== "string") {
+    console.log("DEBUG 418:", typeof status, status);
+  }
+
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-2xl font-bold">🧠 Codex — Code Editing Agent</h1>
@@ -102,8 +106,6 @@ const CodexPage: React.FC = () => {
           {status && (
             <div className="text-sm text-muted-foreground">
               <div className="prose prose-neutral dark:prose-invert max-w-none">
-                {typeof status !== "string" &&
-                  console.log("DEBUG 418:", typeof status, status)}
                 <SafeMarkdown>{toMDString(status)}</SafeMarkdown>
               </div>
             </div>

--- a/frontend/src/app/editor/puck.config.tsx
+++ b/frontend/src/app/editor/puck.config.tsx
@@ -59,6 +59,10 @@ type Props = {
 const MarkdownBlock: React.FC<{ title?: string, content: string, imageUrl?: string }> = ({ title, content, imageUrl }) => {
   // (Optionally, image upload UI - safe to omit if not implemented)
   // You could add upload support here with hooks if you need later.
+  if (typeof content !== "string") {
+    console.log("DEBUG 418:", typeof content, content);
+  }
+
   return (
     <div className="prose prose-neutral dark:prose-invert max-w-none border rounded-xl p-4 bg-background shadow mb-4">
       {title && <h2>{title}</h2>}
@@ -73,8 +77,6 @@ const MarkdownBlock: React.FC<{ title?: string, content: string, imageUrl?: stri
         />
       )}
       <div className="prose prose-neutral dark:prose-invert max-w-none">
-        {typeof content !== "string" &&
-          console.log("DEBUG 418:", typeof content, content)}
         <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
       </div>
     </div>

--- a/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
+++ b/frontend/src/components/ActionQueue/ActionQueuePanel.tsx
@@ -119,6 +119,28 @@ export default function ActionQueuePanel() {
 
   const getActionById = (id: string) => actions.find(a => a.id === id);
 
+  for (const a of actions) {
+    if (a.action.rationale && typeof a.action.rationale !== "string") {
+      console.log("DEBUG 418:", typeof a.action.rationale, a.action.rationale);
+    }
+    if (a.action.diff && typeof a.action.diff !== "string") {
+      console.log("DEBUG 418:", typeof a.action.diff, a.action.diff);
+    }
+    if (typeof a.action.content !== "string") {
+      console.log("DEBUG 418:", typeof a.action.content, a.action.content);
+    }
+    if (a.action.context && typeof a.action.context !== "string") {
+      console.log("DEBUG 418:", typeof a.action.context, a.action.context);
+    }
+    if (Array.isArray(a.history)) {
+      for (const h of a.history) {
+        if (h.comment && typeof h.comment !== "string") {
+          console.log("DEBUG 418:", typeof h.comment, h.comment);
+        }
+      }
+    }
+  }
+
   if (error) return <p className="text-red-500">{error}</p>;
   if (loading) return <p className="text-muted-foreground">Loading queue...</p>;
   if (!actions.length) return <p className="text-muted-foreground">No actions in queue.</p>;
@@ -153,12 +175,6 @@ export default function ActionQueuePanel() {
               <div className="text-xs text-blue-800 mt-1 italic">
                 <strong>Why?</strong>{" "}
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof a.action.rationale !== "string" &&
-                    console.log(
-                      "DEBUG 418:",
-                      typeof a.action.rationale,
-                      a.action.rationale
-                    )}
                   <SafeMarkdown>{toMDString(a.action.rationale)}</SafeMarkdown>
                 </div>
               </div>
@@ -169,12 +185,6 @@ export default function ActionQueuePanel() {
                 <summary className="cursor-pointer text-xs text-blue-700">View Diff</summary>
                 <div className="bg-muted p-2 rounded text-xs overflow-auto whitespace-pre-wrap">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
-                    {typeof a.action.diff !== "string" &&
-                      console.log(
-                        "DEBUG 418:",
-                        typeof a.action.diff,
-                        a.action.diff
-                      )}
                     <SafeMarkdown>{toMDString(a.action.diff)}</SafeMarkdown>
                   </div>
                 </div>
@@ -182,12 +192,6 @@ export default function ActionQueuePanel() {
             ) : (
               <div className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof a.action.content !== "string" &&
-                    console.log(
-                      "DEBUG 418:",
-                      typeof a.action.content,
-                      a.action.content
-                    )}
                   <SafeMarkdown>{toMDString(a.action.content?.slice(0, 500) || "No content")}</SafeMarkdown>
                 </div>
               </div>
@@ -207,12 +211,6 @@ export default function ActionQueuePanel() {
             {showContext[a.id] && a.action.context && (
               <div className="bg-gray-100 p-2 rounded text-xs max-h-32 overflow-auto mt-2">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof a.action.context !== "string" &&
-                    console.log(
-                      "DEBUG 418:",
-                      typeof a.action.context,
-                      a.action.context
-                    )}
                   <SafeMarkdown>{toMDString(a.action.context)}</SafeMarkdown>
                 </div>
               </div>
@@ -267,12 +265,6 @@ export default function ActionQueuePanel() {
                     {h.comment && (
                       <span className="ml-2 italic">
                         <div className="prose prose-neutral dark:prose-invert max-w-none">
-                          {typeof h.comment !== "string" &&
-                            console.log(
-                              "DEBUG 418:",
-                              typeof h.comment,
-                              h.comment
-                            )}
                           <SafeMarkdown>{toMDString(h.comment)}</SafeMarkdown>
                         </div>
                       </span>

--- a/frontend/src/components/AskAgent/ChatMessage.tsx
+++ b/frontend/src/components/AskAgent/ChatMessage.tsx
@@ -15,11 +15,13 @@ export default function ChatMessage({ role, content }: Props) {
   const alignClass =
     role === "user" ? "text-right text-blue-700" : "text-left text-green-700";
 
+  if (typeof content !== "string") {
+    console.log("DEBUG 418:", typeof content, content);
+  }
+
   return (
     <div className={alignClass}>
       <div className="prose prose-neutral dark:prose-invert max-w-none">
-        {typeof content !== "string" &&
-          console.log("DEBUG 418:", typeof content, content)}
         <SafeMarkdown>{toMDString(content)}</SafeMarkdown>
       </div>
     </div>

--- a/frontend/src/components/AskAgent/ChatWindow.tsx
+++ b/frontend/src/components/AskAgent/ChatWindow.tsx
@@ -20,6 +20,17 @@ export default function ChatWindow() {
     bottomRef,
   } = useAskEcho();
 
+  const renderedMessages = messages.map((msg, i) => {
+    if (typeof msg.content !== "string") {
+      console.log("DEBUG 418:", typeof msg.content, msg.content);
+    }
+    return (
+      <>
+        <ChatMessage key={i} role={msg.role} content={toMDString(msg.content)} />
+      </>
+    );
+  });
+
   return (
     <div className="w-full max-w-2xl mx-auto min-h-screen flex flex-col">
       {/* Header */}
@@ -27,13 +38,7 @@ export default function ChatWindow() {
 
       {/* Message List */}
       <div className="flex-1 space-y-2 overflow-y-auto border rounded-xl p-4 bg-muted">
-        {messages.map((msg, i) => (
-          <>
-            {typeof msg.content !== "string" &&
-              console.log("DEBUG 418:", typeof msg.content, msg.content)}
-            <ChatMessage key={i} role={msg.role} content={toMDString(msg.content)} />
-          </>
-        ))}
+        {renderedMessages}
         {loading && (
           <div className="text-left text-green-700 animate-pulse">
             Echo is thinking…

--- a/frontend/src/components/AuditPanel/AuditPanel.tsx
+++ b/frontend/src/components/AuditPanel/AuditPanel.tsx
@@ -154,6 +154,76 @@ export default function AuditPanel() {
   }
 
   // === UI ===
+  const rows = filtered.map((entry, i) => {
+    if (entry.comment && typeof entry.comment !== "string") {
+      console.log("DEBUG 418:", typeof entry.comment, entry.comment);
+    }
+    return (
+      <tr
+        key={i}
+        className="border-t border-gray-300 cursor-pointer hover:bg-blue-50"
+        onClick={() => {
+          setSelected(entry);
+          fetchRelated(entry.id);
+        }}
+      >
+        <td className="px-2 py-1">{entry.timestamp}</td>
+        <td className="px-2 py-1">
+          <Badge
+            variant={
+              entry.status === "approved"
+                ? "success"
+                : entry.status === "denied"
+                ? "destructive"
+                : entry.status === "pending"
+                ? "secondary"
+                : "default"
+            }
+          >
+            {entry.status}
+          </Badge>
+        </td>
+        <td className="px-2 py-1">{entry.user || ""}</td>
+        <td className="px-2 py-1">{entry.type || ""}</td>
+        <td className="px-2 py-1 font-mono">{entry.path || ""}</td>
+        <td className="px-2 py-1 font-mono">{entry.id.slice(0, 8)}</td>
+        <td className="px-2 py-1">
+          {entry.comment ? (
+            <div className="prose prose-neutral dark:prose-invert max-w-none">
+              <SafeMarkdown>{entry.comment}</SafeMarkdown>
+            </div>
+          ) : (
+            ""
+          )}
+        </td>
+      </tr>
+    );
+  });
+
+  if (selected && typeof selected.comment !== "string") {
+    console.log("DEBUG 418:", typeof selected.comment, selected.comment);
+  }
+  if (relatedAction?.action?.context && typeof relatedAction.action.context !== "string") {
+    console.log("DEBUG 418:", typeof relatedAction.action.context, relatedAction.action.context);
+  }
+  if (relatedAction?.action?.rationale && typeof relatedAction.action.rationale !== "string") {
+    console.log(
+      "DEBUG 418:",
+      typeof relatedAction.action.rationale,
+      relatedAction.action.rationale
+    );
+  }
+  if (relatedAction?.action?.diff && typeof relatedAction.action.diff !== "string") {
+    console.log("DEBUG 418:", typeof relatedAction.action.diff, relatedAction.action.diff);
+  }
+  if (relatedAction?.history) {
+    for (const h of relatedAction.history) {
+      if (h.comment && typeof h.comment !== "string") {
+        console.log("DEBUG 418:", typeof h.comment, h.comment);
+      }
+    }
+  }
+
   return (
     <div className="max-w-5xl mx-auto py-8">
       <h2 className="font-bold text-xl mb-6">🛡️ Audit Log & Operator Panel</h2>
@@ -221,39 +291,7 @@ export default function AuditPanel() {
               <th className="px-2 py-1 text-left">Comment</th>
             </tr>
           </thead>
-          <tbody>
-            {filtered.map((entry, i) => (
-              <tr
-                key={i}
-                className="border-t border-gray-300 cursor-pointer hover:bg-blue-50"
-                onClick={() => { setSelected(entry); fetchRelated(entry.id); }}
-              >
-                <td className="px-2 py-1">{entry.timestamp}</td>
-                <td className="px-2 py-1">
-                  <Badge variant={
-                    entry.status === "approved" ? "success" :
-                    entry.status === "denied" ? "destructive" :
-                    entry.status === "pending" ? "secondary" : "default"
-                  }>
-                    {entry.status}
-                  </Badge>
-                </td>
-                <td className="px-2 py-1">{entry.user || ""}</td>
-                <td className="px-2 py-1">{entry.type || ""}</td>
-                <td className="px-2 py-1 font-mono">{entry.path || ""}</td>
-                <td className="px-2 py-1 font-mono">{entry.id.slice(0, 8)}</td>
-                <td className="px-2 py-1">
-                  {entry.comment ? (
-                    <div className="prose prose-neutral dark:prose-invert max-w-none">
-                      {typeof entry.comment !== "string" &&
-                        console.log("DEBUG 418:", typeof entry.comment, entry.comment)}
-                      <SafeMarkdown>{entry.comment}</SafeMarkdown>
-                    </div>
-                  ) : ""}
-                </td>
-              </tr>
-            ))}
-          </tbody>
+          <tbody>{rows}</tbody>
         </table>
       </div>
       <div className="text-xs text-gray-400 mt-3">
@@ -280,12 +318,6 @@ export default function AuditPanel() {
               <strong>Comment:</strong>{" "}
               {selected.comment ? (
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof selected.comment !== "string" &&
-                    console.log(
-                      "DEBUG 418:",
-                      typeof selected.comment,
-                      selected.comment
-                    )}
                   <SafeMarkdown>{selected.comment}</SafeMarkdown>
                 </div>
               ) : ""}
@@ -297,12 +329,6 @@ export default function AuditPanel() {
                 <summary className="cursor-pointer text-blue-700 mb-2">View Agent Context</summary>
                 <div className="bg-gray-50 p-2 rounded text-xs max-h-40 overflow-auto whitespace-pre-wrap">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
-                    {typeof relatedAction.action.context !== "string" &&
-                      console.log(
-                        "DEBUG 418:",
-                        typeof relatedAction.action.context,
-                        relatedAction.action.context
-                      )}
                     <SafeMarkdown>{relatedAction.action.context}</SafeMarkdown>
                   </div>
                 </div>
@@ -312,12 +338,6 @@ export default function AuditPanel() {
               <div className="text-xs italic mb-2">
                 <strong>Agent rationale:</strong>{" "}
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof relatedAction.action.rationale !== "string" &&
-                    console.log(
-                      "DEBUG 418:",
-                      typeof relatedAction.action.rationale,
-                      relatedAction.action.rationale
-                    )}
                   <SafeMarkdown>{relatedAction.action.rationale}</SafeMarkdown>
                 </div>
               </div>
@@ -327,12 +347,6 @@ export default function AuditPanel() {
                 <summary className="cursor-pointer text-blue-700 mb-2">View Diff</summary>
                 <div className="bg-yellow-50 p-2 rounded text-xs max-h-40 overflow-auto whitespace-pre-wrap">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
-                    {typeof relatedAction.action.diff !== "string" &&
-                      console.log(
-                        "DEBUG 418:",
-                        typeof relatedAction.action.diff,
-                        relatedAction.action.diff
-                      )}
                     <SafeMarkdown>{relatedAction.action.diff}</SafeMarkdown>
                   </div>
                 </div>
@@ -349,12 +363,6 @@ export default function AuditPanel() {
                       {h.comment && (
                         <span className="ml-2 italic">
                           <div className="prose prose-neutral dark:prose-invert max-w-none">
-                            {typeof h.comment !== "string" &&
-                              console.log(
-                                "DEBUG 418:",
-                                typeof h.comment,
-                                h.comment
-                              )}
                             <SafeMarkdown>{h.comment}</SafeMarkdown>
                           </div>
                         </span>

--- a/frontend/src/components/Codex/CodexPatchView.tsx
+++ b/frontend/src/components/Codex/CodexPatchView.tsx
@@ -13,6 +13,9 @@ interface Props {
 }
 
 export default function CodexPatchView({ patch, loading = false }: Props) {
+  if (typeof patch !== "string") {
+    console.log("DEBUG 418:", typeof patch, patch);
+  }
   return (
     <div className="mt-4">
       <label htmlFor="codex-patch" className="block text-sm font-medium mb-1">
@@ -28,8 +31,6 @@ export default function CodexPatchView({ patch, loading = false }: Props) {
           "⏳ Codex is generating your patch..."
         ) : patch?.trim() ? (
           <div className="prose prose-neutral dark:prose-invert max-w-none">
-            {typeof patch !== "string" &&
-              console.log("DEBUG 418:", typeof patch, patch)}
             <SafeMarkdown>{patch}</SafeMarkdown>
           </div>
         ) : (

--- a/frontend/src/components/DocsSyncPanel.tsx
+++ b/frontend/src/components/DocsSyncPanel.tsx
@@ -84,6 +84,13 @@ export default function DocsSyncPanel() {
     }
   };
 
+  if (typeof status !== "string") {
+    console.log("DEBUG 418:", typeof status, status);
+  }
+  if (typeof reindexStatus !== "string") {
+    console.log("DEBUG 418:", typeof reindexStatus, reindexStatus);
+  }
+
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">🧠 Sync & Refresh Docs</h2>
@@ -103,8 +110,6 @@ export default function DocsSyncPanel() {
       {status && (
         <div className="mt-2 text-sm text-muted-foreground">
           <div className="prose prose-neutral dark:prose-invert max-w-none">
-            {typeof status !== "string" &&
-              console.log("DEBUG 418:", typeof status, status)}
             <SafeMarkdown>{status}</SafeMarkdown>
           </div>
         </div>
@@ -135,8 +140,6 @@ export default function DocsSyncPanel() {
         {reindexStatus && (
           <div className={`mt-1 text-sm ${reindexStatus.startsWith("✅") ? "text-green-600" : "text-red-500"}`}>
             <div className="prose prose-neutral dark:prose-invert max-w-none">
-              {typeof reindexStatus !== "string" &&
-                console.log("DEBUG 418:", typeof reindexStatus, reindexStatus)}
               <SafeMarkdown>{reindexStatus}</SafeMarkdown>
             </div>
           </div>

--- a/frontend/src/components/DocsViewer/DocsViewer.tsx
+++ b/frontend/src/components/DocsViewer/DocsViewer.tsx
@@ -184,6 +184,18 @@ export default function DocsViewer() {
     setCtxLoading(false);
   }
 
+  if (typeof content !== "string") {
+    console.log("DEBUG 418:", typeof content, content);
+  }
+  for (const hit of hits) {
+    if (typeof hit.snippet !== "string") {
+      console.log("DEBUG 418:", typeof hit.snippet, hit.snippet);
+    }
+  }
+  if (ctxResult && typeof ctxResult !== "string") {
+    console.log("DEBUG 418:", typeof ctxResult, ctxResult);
+  }
+
   // --- UI ---
   return (
     <div className="max-w-5xl mx-auto py-6">
@@ -249,8 +261,6 @@ export default function DocsViewer() {
             <div className="h-[400px] overflow-auto border rounded-md p-4 whitespace-pre-wrap text-sm bg-background">
               {content ? (
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof content !== "string" &&
-                    console.log("DEBUG 418:", typeof content, content)}
                   <SafeMarkdown>{content}</SafeMarkdown>
                 </div>
               ) : (
@@ -297,12 +307,6 @@ export default function DocsViewer() {
                 <div className="font-bold mb-2">{hits[selectedHit].file || "Semantic Snippet"}</div>
                 <div className="bg-gray-100 p-3 rounded max-h-[70vh] overflow-y-auto whitespace-pre-wrap text-xs">
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
-                    {typeof hits[selectedHit].snippet !== "string" &&
-                      console.log(
-                        "DEBUG 418:",
-                        typeof hits[selectedHit].snippet,
-                        hits[selectedHit].snippet
-                      )}
                     <SafeMarkdown>{hits[selectedHit].snippet}</SafeMarkdown>
                   </div>
                 </div>
@@ -339,8 +343,6 @@ export default function DocsViewer() {
               : ctxResult
                 ? (
                     <div className="prose prose-neutral dark:prose-invert max-w-none">
-                    {typeof ctxResult !== "string" &&
-                      console.log("DEBUG 418:", typeof ctxResult, ctxResult)}
                     <SafeMarkdown>{ctxResult}</SafeMarkdown>
                     </div>
                   )

--- a/frontend/src/components/GmailOps/GmailOpsPanel.tsx
+++ b/frontend/src/components/GmailOps/GmailOpsPanel.tsx
@@ -51,6 +51,15 @@ export default function GmailOpsPanel() {
     setEmails(mapped);
   }
 
+  if (msg && typeof msg !== "string") {
+    console.log("DEBUG 418:", typeof msg, msg);
+  }
+  for (const em of emails) {
+    if (typeof em.snippet !== "string") {
+      console.log("DEBUG 418:", typeof em.snippet, em.snippet);
+    }
+  }
+
   return (
     <div className="max-w-2xl mx-auto my-8 space-y-4">
       <div>
@@ -62,8 +71,6 @@ export default function GmailOpsPanel() {
         {msg && (
           <div className="text-xs mt-2">
             <div className="prose prose-neutral dark:prose-invert max-w-none">
-              {typeof msg !== "string" &&
-                console.log("DEBUG 418:", typeof msg, msg)}
               <SafeMarkdown>{msg}</SafeMarkdown>
             </div>
           </div>
@@ -80,8 +87,6 @@ export default function GmailOpsPanel() {
               <div><strong>Date:</strong> {em.date}</div>
               <div className="text-gray-500">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof em.snippet !== "string" &&
-                    console.log("DEBUG 418:", typeof em.snippet, em.snippet)}
                   <SafeMarkdown>{em.snippet}</SafeMarkdown>
                 </div>
               </div>

--- a/frontend/src/components/LogsPanel/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel/LogsPanel.tsx
@@ -94,6 +94,12 @@ export default function LogsPanel() {
       </p>
     );
 
+  for (const entry of filteredLog) {
+    if (entry.result && typeof entry.result !== "string") {
+      console.log("DEBUG 418:", typeof entry.result, entry.result);
+    }
+  }
+
   return (
     <div className="space-y-4">
       {/* Controls */}
@@ -146,8 +152,6 @@ export default function LogsPanel() {
             {typeof entry.result === "string" ? (
               <div className="bg-muted p-2 rounded text-sm overflow-auto whitespace-pre-wrap">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof entry.result !== "string" &&
-                    console.log("DEBUG 418:", typeof entry.result, entry.result)}
                   <SafeMarkdown>{entry.result}</SafeMarkdown>
                 </div>
               </div>

--- a/frontend/src/components/MemoryPanel.tsx
+++ b/frontend/src/components/MemoryPanel.tsx
@@ -158,6 +158,18 @@ export default function MemoryPanel() {
     window.open(`/ask?question=${encodeURIComponent(query)}`, "_blank")
   }
 
+  for (const m of paginated) {
+    if (m.summary && typeof m.summary !== "string") {
+      console.log("DEBUG 418:", typeof m.summary, m.summary)
+    }
+    if (m.agent_response && typeof m.agent_response !== "string") {
+      console.log("DEBUG 418:", typeof m.agent_response, m.agent_response)
+    }
+  }
+  if (modalContext && typeof modalContext.content !== "string") {
+    console.log("DEBUG 418:", typeof modalContext.content, modalContext.content)
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-4 text-xs text-gray-500 mb-2 items-center">
@@ -264,8 +276,6 @@ export default function MemoryPanel() {
             {typeof m.summary === "string" && !!m.summary.trim() && (
               <div className="bg-muted p-2 rounded text-xs whitespace-pre-wrap">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof m.summary !== "string" &&
-                    console.log("DEBUG 418:", typeof m.summary, m.summary)}
                   <SafeMarkdown>{m.summary}</SafeMarkdown>
                 </div>
               </div>
@@ -276,8 +286,6 @@ export default function MemoryPanel() {
               <div className="bg-muted p-2 rounded text-xs whitespace-pre-wrap mt-2">
                 <strong>Agent Response:</strong>
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof m.agent_response !== "string" &&
-                    console.log("DEBUG 418:", typeof m.agent_response, m.agent_response)}
                   <SafeMarkdown>{m.agent_response}</SafeMarkdown>
                 </div>
               </div>
@@ -344,12 +352,6 @@ export default function MemoryPanel() {
             <div className="text-sm mb-2 font-bold">Context File: <code>{modalContext.path}</code></div>
             <div className="bg-gray-100 p-4 rounded max-h-[400px] overflow-auto text-xs">
               <div className="prose prose-neutral dark:prose-invert max-w-none">
-                {typeof modalContext.content !== "string" &&
-                  console.log(
-                    "DEBUG 418:",
-                    typeof modalContext.content,
-                    modalContext.content
-                  )}
                 <SafeMarkdown>{modalContext.content}</SafeMarkdown>
               </div>
             </div>

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -116,6 +116,12 @@ export default function SearchPanel() {
     fetchResults(query.trim());
   };
 
+  for (const r of results) {
+    if (typeof r.snippet !== "string") {
+      console.log("DEBUG 418:", typeof r.snippet, r.snippet);
+    }
+  }
+
   return (
     <div className="space-y-4" aria-busy={loading}>
       <form onSubmit={onSubmit} className="flex gap-2">
@@ -144,8 +150,6 @@ export default function SearchPanel() {
               </header>
               <div className="mb-1">
                 <div className="prose prose-neutral dark:prose-invert max-w-none">
-                  {typeof r.snippet !== "string" &&
-                    console.log("DEBUG 418:", typeof r.snippet, r.snippet)}
                   <SafeMarkdown>{r.snippet}</SafeMarkdown>
                 </div>
               </div>

--- a/frontend/src/components/ui/AskAgent/AskAgent.tsx
+++ b/frontend/src/components/ui/AskAgent/AskAgent.tsx
@@ -32,6 +32,10 @@ export default function AskAgent() {
     setLoading(false)
   }
 
+  if (response && typeof response !== "string") {
+    console.log("DEBUG 418:", typeof response, response)
+  }
+
   return (
     <div className="max-w-xl space-y-4">
       <Textarea
@@ -46,8 +50,6 @@ export default function AskAgent() {
       {response && (
         <div className="bg-muted p-4 rounded text-sm whitespace-pre-wrap border">
           <div className="prose prose-neutral dark:prose-invert max-w-none">
-            {typeof response !== "string" &&
-              console.log("DEBUG 418:", typeof response, response)}
             <SafeMarkdown>{response}</SafeMarkdown>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move all `console.log` calls outside of JSX expressions
- keep side effects before rendering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68646ee3416083279182bf58c4915fe6