### PR TITLE
Switch agent APIs to query param

### DIFF
--- a/agents/codex_agent.py
+++ b/agents/codex_agent.py
@@ -26,12 +26,12 @@ class CodexAgent:
     """
 
     async def handle(
-        self, message: str, context: str, user_id: Optional[str] = None
+        self, query: str, context: str, user_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Handles a code-editing request. Generates a patch using GPT-4o, validates, then critiques it.
         Args:
-            message: User's natural language request
+            query: User's natural language request
             context: Relevant code context (usually file contents)
             user_id: (optional) User ID for logging
         Returns:
@@ -39,10 +39,10 @@ class CodexAgent:
                 - response: summary of patch
                 - action: patch dict with critic scores
         """
-        if not message or not context:
-            raise ValueError("Both 'message' and 'context' must be provided.")
+        if not query or not context:
+            raise ValueError("Both 'query' and 'context' must be provided.")
 
-        prompt = self._build_prompt(message, context)
+        prompt = self._build_prompt(query, context)
 
         try:
             completion = await client.chat.completions.create(
@@ -96,22 +96,22 @@ class CodexAgent:
         }
 
     async def stream(
-        self, message: str, context: str, user_id: Optional[str] = None
+        self, query: str, context: str, user_id: Optional[str] = None
     ) -> AsyncGenerator[str, None]:
         """
         Streams the patch generation output from the LLM (line by line).
         Args:
-            message: User's code-edit request
+            query: User's code-edit request
             context: Relevant code context
             user_id: (optional) User ID
         Yields:
             str: The next output chunk from the model or error.
         """
-        if not message or not context:
-            yield "[Error] Missing message or context."
+        if not query or not context:
+            yield "[Error] Missing query or context."
             return
 
-        prompt = self._build_prompt(message, context)
+        prompt = self._build_prompt(query, context)
 
         try:
             openai_stream = await client.chat.completions.create(
@@ -130,13 +130,13 @@ class CodexAgent:
         except Exception as e:
             yield f"[Error] Codex stream failed: {str(e)}"
 
-    def _build_prompt(self, message: str, context: str) -> str:
+    def _build_prompt(self, query: str, context: str) -> str:
         """
         Builds a system prompt for the LLM including task and code context.
         """
         return (
             "You will receive a code editing request from a user, along with the relevant code context.\n\n"
-            f"Task: {message}\n\n"
+            f"Task: {query}\n\n"
             "Code Context:\n"
             "```python\n"
             f"{context}\n"

--- a/agents/critic_agent/run.py
+++ b/agents/critic_agent/run.py
@@ -81,14 +81,14 @@ import json
 from core.logging import log_event
 
 # === Relay-compatible runner ===
-async def run(message: str, context: str, user_id: str = "system") -> List[Dict]:
+async def run(query: str, context: str, user_id: str = "system") -> List[Dict]:
     """
     Handles relay requests to 'critic' role.
     Expects context to be a JSON-encoded plan object.
     """
     try:
         plan = json.loads(context)
-        results = run_critics(plan, query=message)
+        results = run_critics(plan, query=query)
 
         log_event("critic_agent_result", {
             "user": user_id,

--- a/agents/janitor_agent.py
+++ b/agents/janitor_agent.py
@@ -1,6 +1,6 @@
 # agents/janitor_agent.py
 
-async def run(message: str, context: str, user_id: str = "system") -> dict:
+async def run(query: str, context: str, user_id: str = "system") -> dict:
     """
     Summarizes memory logs, detects duplicates, removes noise, and compresses the log footprint.
     """

--- a/agents/mcp_agent.py
+++ b/agents/mcp_agent.py
@@ -85,7 +85,7 @@ async def run_mcp(
     except Exception as e:
         log_event("mcp_context_error", {"error": str(e), "trace": traceback.format_exc()})
         # Echo always as fallback, even if context build fails
-        fallback = await echo_agent_run(message=query, context="", user_id=user_id)
+        fallback = await echo_agent_run(query=query, context="", user_id=user_id)
         return {
             "plan": None,
             "routed_result": fallback,
@@ -117,10 +117,10 @@ async def run_mcp(
             routed_result = None
             try:
                 if handler:
-                    routed_result = await handler(message=query, context=context, user_id=user_id)
+                    routed_result = await handler(query=query, context=context, user_id=user_id)
                 else:
                     log_event("mcp_fallback_echo", {"reason": f"No handler for route '{route}'"})
-                    routed_result = await echo_agent_run(message=query, context=context, user_id=user_id)
+                    routed_result = await echo_agent_run(query=query, context=context, user_id=user_id)
             except Exception as agent_exc:
                 log_event("mcp_agent_handler_error", {
                     "role": role,
@@ -128,7 +128,7 @@ async def run_mcp(
                     "error": str(agent_exc),
                     "trace": traceback.format_exc()
                 })
-                routed_result = await echo_agent_run(message=query, context=context, user_id=user_id)
+                routed_result = await echo_agent_run(query=query, context=context, user_id=user_id)
 
             # --- Critic Validation: always pass the extracted plan/patch, and user query (not context!) ---
             plan_to_critique = extract_plan_for_critics(route, routed_result)
@@ -156,7 +156,7 @@ async def run_mcp(
             handler = ROUTING_TABLE[role]
             log_event("mcp_dispatch", {"role": role})
             try:
-                routed_result = await handler(message=query, context=context, user_id=user_id)
+                routed_result = await handler(query=query, context=context, user_id=user_id)
             except Exception as agent_exc:
                 log_event("mcp_agent_handler_error", {
                     "role": role,
@@ -164,7 +164,7 @@ async def run_mcp(
                     "error": str(agent_exc),
                     "trace": traceback.format_exc()
                 })
-                routed_result = await echo_agent_run(message=query, context=context, user_id=user_id)
+                routed_result = await echo_agent_run(query=query, context=context, user_id=user_id)
             result = {
                 "plan": None,
                 "routed_result": routed_result,
@@ -177,7 +177,7 @@ async def run_mcp(
         else:
             # Unknown role: always fallback to Echo
             log_event("mcp_fallback_echo", {"reason": f"Unknown role '{role}'"})
-            routed_result = await echo_agent_run(message=query, context=context, user_id=user_id)
+            routed_result = await echo_agent_run(query=query, context=context, user_id=user_id)
             result = {
                 "plan": None,
                 "routed_result": routed_result,
@@ -196,7 +196,7 @@ async def run_mcp(
     except Exception as e:
         log_event("mcp_agent_error", {"role": role, "error": str(e), "trace": traceback.format_exc()})
         # Echo as final fallback if MCP main loop itself errors
-        routed_result = await echo_agent_run(message=query, context=context, user_id=user_id)
+        routed_result = await echo_agent_run(query=query, context=context, user_id=user_id)
         return {
             "plan": None,
             "routed_result": routed_result,

--- a/agents/memory_agent.py
+++ b/agents/memory_agent.py
@@ -47,7 +47,7 @@ class MemoryAgent:
 memory_agent = MemoryAgent()
 
 # === Relay-compatible route handler ===
-async def run(message: str, context: str, user_id: str = "anonymous") -> Dict:
+async def run(query: str, context: str, user_id: str = "anonymous") -> Dict:
     """
     Returns a summary of the most recent memory logs for the user.
     """

--- a/agents/metaplanner_agent.py
+++ b/agents/metaplanner_agent.py
@@ -48,7 +48,7 @@ async def suggest_route(query: str, plan: dict, user_id: str = "anonymous") -> s
     return original_route
 
 # === Agent-standard route handler ===
-async def run(message: str, context: str, user_id: str = "anonymous") -> dict:
+async def run(query: str, context: str, user_id: str = "anonymous") -> dict:
     """
     Standard Relay agent handler for 'meta' route.
     This allows you to run the MetaPlanner as a standalone agent.
@@ -63,9 +63,9 @@ async def run(message: str, context: str, user_id: str = "anonymous") -> dict:
     try:
         plan = {
             "route": "planner",
-            "objective": message,
+            "objective": query,
         }
-        suggested = await suggest_route(message, plan, user_id=user_id)
+        suggested = await suggest_route(query, plan, user_id=user_id)
         used_fallback = suggested == plan["route"]
         return {
             "suggested_route": suggested,

--- a/agents/simulation_agent.py
+++ b/agents/simulation_agent.py
@@ -31,7 +31,7 @@ class SimulationAgent:
 simulation_agent = SimulationAgent()
 
 # === Relay-compatible route handler ===
-async def run(message: str, context: str, user_id: str = "system") -> Dict[str, Any]:
+async def run(query: str, context: str, user_id: str = "system") -> Dict[str, Any]:
     """
     Relay handler for 'simulate' route. Parses plan from context and runs a sandbox check.
     """
@@ -40,7 +40,7 @@ async def run(message: str, context: str, user_id: str = "system") -> Dict[str, 
         result = simulation_agent.simulate_plan(plan)
         log_event("simulation_agent_result", {
             "user": user_id,
-            "message": message,
+            "query": query,
             "result": result
         })
         return result

--- a/routes/control.py
+++ b/routes/control.py
@@ -119,7 +119,7 @@ async def approve_action(data: dict = Body(...), user=Depends(auth)):
 
     if handler:
         result = await handler(
-            message=action_data.get("query", ""),
+            query=action_data.get("query", ""),
             context=action_data.get("context", {}),
             user_id=user
         )

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -27,7 +27,7 @@ async def test_ask_stream_rejects_bad_input():
 
 @pytest.mark.asyncio
 async def test_codex_stream_endpoint(monkeypatch):
-    async def dummy_stream(message: str, context: str, user_id=None):
+    async def dummy_stream(query: str, context: str, user_id=None):
         yield "patch1"
         yield "patch2"
 


### PR DESCRIPTION
## Summary
- update all agent handler signatures to use `query` instead of `message`
- adjust MCP and control routing to call handlers with `query`
- update tests for new parameter name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686588a7e0d48327bda0049e6e5917a1