### PR TITLE
Add Search page and restore Gmail Ops

### DIFF
--- a/frontend/src/app/gmail-ops/page.tsx
+++ b/frontend/src/app/gmail-ops/page.tsx
@@ -1,15 +1,11 @@
-// File: src/app/gmail-ops/page.tsx
-// Purpose: Placeholder for GmailOps route — prevents build error by ensuring layout context
-
-'use client'
-
-// import GmailOpsPanel from '@/components/GmailOps/GmailOpsPanel'
+"use client";
+import GmailOpsPanel from "@/components/GmailOps/GmailOpsPanel";
 
 export default function GmailOpsPage() {
   return (
-    <div className="p-6 text-sm text-gray-500">
-      {/* <GmailOpsPanel /> */}
-      GmailOps is temporarily disabled.
-    </div>
-  )
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">✉️ Gmail Ops</h1>
+      <GmailOpsPanel />
+    </main>
+  );
 }

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import SearchPanel from "@/components/SearchPanel";
+
+export default function SearchPage() {
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">🔍 Search</h1>
+      <SearchPanel />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `search` page to host `SearchPanel`
- restore `gmail-ops` page by rendering `GmailOpsPanel`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'neo4j')*

------
https://chatgpt.com/codex/tasks/task_e_686b05ba6ee08327b6b3b9fc3625df19