### PR TITLE
Fix PostCSS plugin for Tailwind

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,7 +1,7 @@
 // frontend/postcss.config.js
 module.exports = {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
+    "@tailwindcss/postcss": {},
+    autoprefixer: {},
+  },
 }


### PR DESCRIPTION
## Summary
- fix PostCSS configuration to use `@tailwindcss/postcss`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b01c397f083278b2d5c4ee96ef2c9